### PR TITLE
test: adding bool return contract for tests

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+"src/for-test/boolean_return",
 "src/token_contract",
 "src/escrow_contract"
 ]

--- a/src/for-test/boolean_return/Nargo.toml
+++ b/src/for-test/boolean_return/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "boolean_return"
+authors = [""]
+compiler_version = ">=1.0.0"
+type = "contract"
+
+[dependencies]
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.72.1", directory = "noir-projects/aztec-nr/aztec" }

--- a/src/for-test/boolean_return/src/main.nr
+++ b/src/for-test/boolean_return/src/main.nr
@@ -1,0 +1,33 @@
+use dep::aztec::macros::aztec;
+
+#[aztec]
+// Mocked boolean return contract for tests
+pub contract BooleanReturn {
+    use dep::aztec::{
+        macros::{functions::{initializer, private, public, view}, storage::storage},
+        prelude::PublicImmutable,
+    };
+
+    #[storage]
+    struct Storage<Context> {
+        return_value: PublicImmutable<bool, Context>,
+    }
+
+    #[public]
+    #[initializer]
+    fn constructor(return_value: bool) {
+        storage.return_value.initialize(return_value);
+    }
+
+    #[view]
+    #[private]
+    fn get_boolean_in_private() -> bool {
+        storage.return_value.read()
+    }
+
+    #[view]
+    #[public]
+    fn get_boolean_in_public() -> bool {
+        storage.return_value.read()
+    }
+}


### PR DESCRIPTION
this contract should help us test the behaviour in a vested agreement, in which (for example) when Alice creates a vest for Bob, this external call may represent the "clawback check", if it returns `False` then Bob can continue claiming the vest, if it returns `True`, then Alice should be able to claim the funds.