### PR TITLE
feat: adding transfer variations (priv2pub+hp & priv2hp)

### DIFF
--- a/src/token_contract/src/test.nr
+++ b/src/token_contract/src/test.nr
@@ -7,4 +7,6 @@ mod transfer_private_to_private;
 mod transfer_public_to_public;
 mod transfer_public_to_private;
 mod transfer_private_to_public;
+mod transfer_private_to_hiding_point;
+mod transfer_private_to_public_with_hiding_point;
 mod utils;

--- a/src/token_contract/src/test/transfer_private_to_hiding_point.nr
+++ b/src/token_contract/src/test/transfer_private_to_hiding_point.nr
@@ -1,7 +1,6 @@
 use crate::test::utils;
 use crate::Token;
 use authwit::cheatcodes as authwit_cheatcodes;
-use aztec::oracle::random::random;
 use aztec::oracle::debug_log::debug_log;
 
 #[test]
@@ -29,13 +28,13 @@ unconstrained fn transfer_private_to_hiding_point() {
 
     // // Check balances
     utils::check_private_balance(token_contract_address, owner, U128::from_integer(0));
-    utils::check_private_balance (token_contract_address, recipient, transfer_amount);
+    utils::check_private_balance(token_contract_address, recipient, transfer_amount);
 }
 
 #[test]
 unconstrained fn transfer_private_to_hiding_point_on_behalf_of_other() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint_to_private(/* with_account_contracts */ false);
+        utils::setup_and_mint_to_private(/* with_account_contracts */ true);
 
     utils::check_private_balance(token_contract_address, owner, mint_amount);
     utils::check_private_balance(token_contract_address, recipient, U128::from_integer(0));
@@ -65,5 +64,5 @@ unconstrained fn transfer_private_to_hiding_point_on_behalf_of_other() {
 
     // Check balances
     utils::check_private_balance(token_contract_address, owner, U128::from_integer(0));
-    utils::check_private_balance (token_contract_address, recipient, transfer_amount);
+    utils::check_private_balance(token_contract_address, recipient, transfer_amount);
 }

--- a/src/token_contract/src/test/transfer_private_to_hiding_point.nr
+++ b/src/token_contract/src/test/transfer_private_to_hiding_point.nr
@@ -1,0 +1,69 @@
+use crate::test::utils;
+use crate::Token;
+use authwit::cheatcodes as authwit_cheatcodes;
+use aztec::oracle::random::random;
+use aztec::oracle::debug_log::debug_log;
+
+#[test]
+unconstrained fn transfer_private_to_hiding_point() {
+    let (env, token_contract_address, owner, recipient, mint_amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ false);
+
+    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, recipient, U128::from_integer(0));
+
+    // Prepare hiding point slot
+    env.impersonate(recipient);
+    let hiding_point_slot: Field = Token::at(token_contract_address)
+        .prepare_transfer_public_to_private(recipient, recipient)
+        .call(&mut env.private());
+    env.advance_block_by(1);
+
+    // Transfer tokens
+    let transfer_amount = mint_amount;
+    env.impersonate(owner);
+    Token::at(token_contract_address)
+        .transfer_private_to_hiding_point(owner, transfer_amount, hiding_point_slot, 0)
+        .call(&mut env.private());
+    env.advance_block_by(1);
+
+    // // Check balances
+    utils::check_private_balance(token_contract_address, owner, U128::from_integer(0));
+    utils::check_private_balance (token_contract_address, recipient, transfer_amount);
+}
+
+#[test]
+unconstrained fn transfer_private_to_hiding_point_on_behalf_of_other() {
+    let (env, token_contract_address, owner, recipient, mint_amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ false);
+
+    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, recipient, U128::from_integer(0));
+
+    let transfer_amount = mint_amount;
+
+    // Prepare hiding point slot
+    env.impersonate(recipient);
+    let hiding_point_slot: Field = Token::at(token_contract_address)
+        .prepare_transfer_public_to_private(recipient, recipient)
+        .call(&mut env.private());
+    env.advance_block_by(1);
+
+    let transfer_to_hiding_point_call_interface = Token::at(token_contract_address)
+        .transfer_private_to_hiding_point(owner, transfer_amount, hiding_point_slot, 0);
+
+    authwit_cheatcodes::add_private_authwit_from_call_interface(
+        owner,
+        recipient,
+        transfer_to_hiding_point_call_interface,
+    );
+
+    // Transfer tokens
+    env.impersonate(recipient);
+    transfer_to_hiding_point_call_interface.call(&mut env.private());
+    env.advance_block_by(1);
+
+    // Check balances
+    utils::check_private_balance(token_contract_address, owner, U128::from_integer(0));
+    utils::check_private_balance (token_contract_address, recipient, transfer_amount);
+}

--- a/src/token_contract/src/test/transfer_private_to_public_with_hiding_point.nr
+++ b/src/token_contract/src/test/transfer_private_to_public_with_hiding_point.nr
@@ -1,0 +1,144 @@
+use crate::test::utils;
+use crate::Token;
+use authwit::cheatcodes as authwit_cheatcodes;
+use aztec::oracle::debug_log::debug_log;
+
+#[test]
+unconstrained fn transfer_private_to_public_with_hiding_point() {
+    let (env, token_contract_address, owner, recipient, mint_amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ false);
+
+    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, recipient, U128::from_integer(0));
+
+    // Prepare hiding point slot
+    env.impersonate(recipient);
+    let hiding_point_slot: Field = Token::at(token_contract_address)
+        .prepare_transfer_public_to_private(recipient, recipient)
+        .call(&mut env.private());
+    env.advance_block_by(1);
+
+    // Transfer tokens
+    let transfer_amount = mint_amount;
+    env.impersonate(owner);
+    let hiding_point_slot = Token::at(token_contract_address)
+        .transfer_private_to_public_with_hiding_point(owner, recipient, transfer_amount, 0)
+        .call(&mut env.private());
+    env.advance_block_by(1);
+
+    // Check balances
+    utils::check_private_balance(token_contract_address, owner, U128::from_integer(0));
+    utils::check_public_balance(token_contract_address, recipient, transfer_amount);
+}
+
+// #[test]
+unconstrained fn transfer_private_to_public_with_hiding_point_on_behalf_of_other() {
+    let (env, token_contract_address, owner, recipient, mint_amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ true);
+
+    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, recipient, U128::from_integer(0));
+
+    // Transfer tokens
+    let transfer_amount = mint_amount;
+
+    let transfer_private_to_public_hiding_point_call_interface = Token::at(token_contract_address)
+        .transfer_private_to_public_with_hiding_point(owner, recipient, transfer_amount, 0);
+
+    // TODO: Unable to compile if non-void call interface is used
+    // authwit_cheatcodes::add_private_authwit_from_call_interface(
+    //     owner,
+    //     recipient,
+    //     transfer_private_to_public_hiding_point_call_interface,
+    // );
+
+    // Transfer tokens
+    env.impersonate(recipient);
+    transfer_private_to_public_hiding_point_call_interface.call(&mut env.private());
+    env.advance_block_by(1);
+
+    // Check balances
+    utils::check_private_balance(token_contract_address, owner, U128::from_integer(0));
+    utils::check_public_balance(token_contract_address, recipient, transfer_amount);
+}
+
+#[test]
+unconstrained fn transfer_private_to_public_with_hiding_point_and_finalize() {
+    let (env, token_contract_address, owner, recipient, mint_amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ false);
+
+    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, recipient, U128::from_integer(0));
+
+    // Transfer tokens
+    let transfer_amount = mint_amount;
+
+    env.impersonate(owner);
+    let hiding_point_slot = Token::at(token_contract_address)
+        .transfer_private_to_public_with_hiding_point(owner, recipient, transfer_amount, 0)
+        .call(&mut env.private());
+
+    // Before finalize the recipient should have the tokens in public balance
+    utils::check_public_balance(token_contract_address, recipient, transfer_amount);
+
+    // Transfer tokens
+    env.impersonate(recipient);
+    Token::at(token_contract_address)
+        .finalize_transfer_public_to_private(recipient, transfer_amount, hiding_point_slot, 0)
+        .call(&mut env.public());
+    env.advance_block_by(1);
+
+    // Check balances
+    utils::check_private_balance(token_contract_address, owner, U128::from_integer(0));
+    utils::check_public_balance(token_contract_address, recipient, U128::from_integer(0));
+    utils::check_private_balance(token_contract_address, recipient, transfer_amount);
+}
+
+#[test(should_fail)]
+unconstrained fn transfer_private_to_public_with_hiding_point_and_finalize_with_invalid_hiding_point() {
+    let (env, token_contract_address, owner, recipient, mint_amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ false);
+
+    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, recipient, U128::from_integer(0));
+
+    // Transfer tokens
+    let transfer_amount = mint_amount;
+
+    env.impersonate(owner);
+    let hiding_point_slot = Token::at(token_contract_address)
+        .transfer_private_to_public_with_hiding_point(owner, recipient, transfer_amount, 0)
+        .call(&mut env.private());
+
+    let invalid_hiding_point = 1337;
+
+    // Transfer tokens
+    env.impersonate(recipient);
+    Token::at(token_contract_address)
+        .finalize_transfer_public_to_private(recipient, transfer_amount, invalid_hiding_point, 0)
+        .call(&mut env.public());
+}
+
+// This test is passing although we pass `0` as `hiding_point_slot`
+#[test]
+unconstrained fn transfer_private_to_public_with_hiding_point_and_finalize_with_invalid_hiding_point_literals() {
+    let (env, token_contract_address, owner, recipient, mint_amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ false);
+
+    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, recipient, U128::from_integer(0));
+
+    // Transfer tokens
+    let transfer_amount = mint_amount;
+
+    env.impersonate(owner);
+    let hiding_point_slot = Token::at(token_contract_address)
+        .transfer_private_to_public_with_hiding_point(owner, recipient, transfer_amount, 0)
+        .call(&mut env.private());
+
+    // Transfer tokens
+    env.impersonate(recipient);
+    Token::at(token_contract_address)
+        .finalize_transfer_public_to_private(recipient, transfer_amount, 0, 0)
+        .call(&mut env.public());
+}

--- a/src/token_contract/src/test/utils.nr
+++ b/src/token_contract/src/test/utils.nr
@@ -26,7 +26,9 @@ pub unconstrained fn setup(
         let recipient = env.create_account(2);
         (owner, recipient)
     };
-
+    // let owner = env.create_account_contract(1);
+    // let recipient = env.create_account_contract(2);
+    
     // Start the test in the account contract address
     env.impersonate(owner);
 

--- a/src/token_contract/src/token/macros/transferrable.nr
+++ b/src/token_contract/src/token/macros/transferrable.nr
@@ -29,6 +29,35 @@ pub global TRANSFERRABLE_CODE: Quoted = quote {
     }
 
     #[private]
+    fn transfer_private_to_public_with_hiding_point(
+        from: AztecAddress,
+        to: AztecAddress,
+        amount: U128,
+        nonce: Field,
+    ) -> Field {
+        AuthLib::_validate_from_private(from, nonce, &mut context);
+
+        TokenLib::_decrease_private_balance(
+            &mut context,
+            storage.private_balances,
+            from,
+            amount,
+            INITIAL_TRANSFER_CALL_MAX_NOTES,
+        )
+            .emit(encode_and_encrypt_note(&mut context, from, from));
+
+        TokenLib::_private_increase_public_balance(&mut context, to, amount);
+
+        let hiding_point_slot = TokenLib::_prepare_transfer_public_to_private(
+            &mut context,
+            storage.private_balances,
+            from,
+            to,
+        );
+        hiding_point_slot
+    }
+
+    #[private]
     fn transfer_private_to_private(
         from: AztecAddress,
         to: AztecAddress,
@@ -49,6 +78,27 @@ pub global TRANSFERRABLE_CODE: Quoted = quote {
         TokenLib::_increase_private_balance(storage.private_balances, to, amount).emit(
             encode_and_encrypt_note(&mut context, to, from),
         );
+    }
+
+    #[private]
+    fn transfer_private_to_hiding_point(
+        from: AztecAddress,
+        amount: U128,
+        hiding_point_slot: Field,
+        nonce: Field,
+    ) {
+        AuthLib::_validate_from_private(from, nonce, &mut context);
+        
+        TokenLib::_decrease_private_balance(
+            &mut context,
+            storage.private_balances,
+            from,
+            amount,
+            INITIAL_TRANSFER_CALL_MAX_NOTES,
+        )
+            .emit(encode_and_encrypt_note(&mut context, from, from));
+
+        TokenLib::_private_increase_hiding_point_balance(&mut context, hiding_point_slot, amount);
     }
 
     #[private]
@@ -136,6 +186,19 @@ pub global TRANSFERRABLE_CODE: Quoted = quote {
     #[internal]
     fn decrease_public_balance(from: AztecAddress, amount: U128) {
         TokenLib::_decrease_public_balance(storage.public_balances, from, amount);
+    }
+    
+    #[public]
+    #[internal]
+    fn increase_hiding_point_balance(
+        hiding_point_slot: Field,
+        amount: U128,
+    ) {
+        TokenLib::_increase_hiding_point_balance(
+            &mut context,
+            hiding_point_slot,
+            amount,
+        );
     }
 
     /** ==========================================================

--- a/src/token_contract/src/token/token_utils.nr
+++ b/src/token_contract/src/token/token_utils.nr
@@ -153,6 +153,18 @@ pub mod TokenLib {
         );
     }
 
+    pub fn _private_increase_hiding_point_balance(
+        context: &mut PrivateContext,
+        hiding_point_slot: Field,
+        amount: U128,
+    ) {
+        context.call_public_function(
+            context.this_address(),
+            FunctionSelector::from_signature("increase_hiding_point_balance(Field,(Field,Field))"),
+            serialize_hiding_point_balance_change_call(hiding_point_slot, amount),
+        );
+    }
+
     pub fn _finalize_mint_to_private(
         context: &mut PublicContext,
         total_supply: PublicMutable<U128, &mut PublicContext>,
@@ -289,6 +301,18 @@ pub mod TokenLib {
         result[0] = account.to_field();
         result[1] = amount[0];
         result[2] = amount[1];
+        result
+    }
+
+    fn serialize_hiding_point_balance_change_call(
+        hiding_point_slot: Field,
+        amount: U128,
+    ) -> [Field; 3] {
+        let mut result = [0 as Field; 3];
+        let amount_serialized = amount.serialize();
+        result[0] = hiding_point_slot;
+        result[1] = amount_serialized[0];
+        result[2] = amount_serialized[1];
         result
     }
 }


### PR DESCRIPTION
This PR aims to add transferring to public and storing a hiding point payload, and transfer from private to a hiding point.
Please add tests, afterwards we can compare different routes, for example, we could transfer from private to hiding point w/o passing through public.