### PR TITLE
feat: leak escrow keys

### DIFF
--- a/jest.integration.config.json
+++ b/jest.integration.config.json
@@ -8,5 +8,5 @@
   },
   "testRegex": "./src/.*\\.test\\.ts$",
   "rootDir": "./src",
-  "testTimeout": 30000
+  "testTimeout": 60000
 }

--- a/src/clawback_escrow/src/main.nr
+++ b/src/clawback_escrow/src/main.nr
@@ -29,8 +29,7 @@ pub contract ClawbackEscrow {
     #[private]
     fn create_clawback_escrow(escrow: AztecAddress, receiver: AztecAddress) {
         // This will revert if the Clawback Escrow is not the owner of the escrow
-        // TODO: temporary disable leaking keys
-        // Escrow::at(escrow).leak_keys(receiver).call(&mut context);
+        Escrow::at(escrow).leak_keys(receiver).call(&mut context);
 
         let sender = context.msg_sender();
         let mut note = ClawbackEscrowNote::new(sender, receiver, escrow);

--- a/src/clawback_escrow/src/main.nr
+++ b/src/clawback_escrow/src/main.nr
@@ -71,7 +71,7 @@ pub contract ClawbackEscrow {
 
         assert(caller == note.sender, "Only sender can clawback");
 
-        Escrow::at(escrow).withdraw(token, amount, caller).call(&mut context);
+        Escrow::at(escrow).withdraw(token, amount, note.sender).call(&mut context);
     }
 
     /** ==========================================================

--- a/src/clawback_escrow/src/main.nr
+++ b/src/clawback_escrow/src/main.nr
@@ -54,7 +54,6 @@ pub contract ClawbackEscrow {
         // There should only be one note per escrow
         let note = _find_clawback_note(storage, escrow);
 
-        assert(note.escrow == escrow, "Invalid escrow address");
         assert(caller == note.receiver, "Only receiver can claim");
 
         Escrow::at(escrow).withdraw(token, amount, note.receiver).call(&mut context);
@@ -66,8 +65,6 @@ pub contract ClawbackEscrow {
 
         // There should only be one note per escrow
         let note = _find_clawback_note(storage, escrow);
-
-        assert(note.escrow == escrow, "Invalid escrow address");
 
         assert(caller == note.sender, "Only sender can clawback");
 
@@ -91,7 +88,6 @@ pub contract ClawbackEscrow {
         // We revert if there is no note in the filter so we can probably unwrap directly
         let unwrapped_note = notes.get_unchecked(0);
 
-        assert(unwrapped_note.escrow == escrow, "Invalid escrow address");
         unwrapped_note
     }
 }

--- a/src/clawback_escrow/src/types/clawback_escrow_note.nr
+++ b/src/clawback_escrow/src/types/clawback_escrow_note.nr
@@ -26,7 +26,7 @@ pub struct ClawbackEscrowNote {
 impl NullifiableNote for ClawbackEscrowNote {
     fn compute_nullifier(self, _: &mut PrivateContext, note_hash_for_nullify: Field) -> Field {
         poseidon2_hash_with_separator(
-            [note_hash_for_nullify, self.escrow.to_field()],
+            [note_hash_for_nullify],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
         )
     }
@@ -34,7 +34,7 @@ impl NullifiableNote for ClawbackEscrowNote {
     unconstrained fn compute_nullifier_without_context(self) -> Field {
         let note_hash_for_nullify = compute_note_hash_for_nullify(self);
         poseidon2_hash_with_separator(
-            [note_hash_for_nullify, self.escrow.to_field()],
+            [note_hash_for_nullify],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
         )
     }

--- a/src/escrow_contract/src/main.nr
+++ b/src/escrow_contract/src/main.nr
@@ -9,6 +9,7 @@ pub contract Escrow {
         encrypted_logs::log_assembly_strategies::default_aes128::{
             event::encode_and_encrypt_event, note::encode_and_encrypt_note,
         },
+        event::event_interface::EventInterface,
         keys::getters::get_public_keys,
         macros::{events::event, functions::{initializer, private}, storage::storage},
         prelude::{AztecAddress, PrivateImmutable},
@@ -22,10 +23,9 @@ pub contract Escrow {
 
     #[derive(Serialize)]
     #[event]
-    struct PrivacyKeys {
-        // TODO: fetch and add encryption_keys to event
-        // encryption_keys: Field,
-        nullification_keys: Field,
+    struct EscrowKeys {
+        nullification_secret: Field,
+        escrow_secret: Field,
     }
 
     #[storage]
@@ -47,21 +47,19 @@ pub contract Escrow {
      * ======================= PRIVATE ===========================
      * ======================================================== */
 
-    // Leaks privacy keys of this contract to a recipient
+    // Leaks secret keys of this contract to a recipient
     #[private]
     fn leak_keys(to: AztecAddress) {
         let sender = context.msg_sender();
         let note = storage.owner.get_note();
         assert(note.owner == sender);
-        let owner_npk_m_hash = get_public_keys(context.this_address()).npk_m.hash();
-        let nullification_secret = context.request_nsk_app(owner_npk_m_hash);
+        let self_npk_m_hash = get_public_keys(context.this_address()).npk_m.hash();
+        let nullification_secret = context.request_nsk_app(self_npk_m_hash);
 
-        let leak_event = PrivacyKeys {
-            // encryption_keys: encryption_secret,
-            nullification_keys: nullification_secret,
-        };
+        let leak_event =
+            EscrowKeys { nullification_secret: nullification_secret, escrow_secret: note.secret };
 
-        leak_event.emit(encode_and_encrypt_event(&mut context, to, context.this_address()))
+        leak_event.emit(encode_and_encrypt_event(&mut context, to, context.this_address()));
     }
 
     // Withdraws balance. Requires that msg.sender is the owner

--- a/src/escrow_contract/src/test/constructor.nr
+++ b/src/escrow_contract/src/test/constructor.nr
@@ -3,7 +3,8 @@ use crate::types::account_note::AccountNote;
 
 #[test]
 unconstrained fn constructor_storage() {
-    let (env, escrow_address, owner, recipient, escrow_secret) = utils::setup(/* with_account_contracts */ true);
+    let (env, escrow_address, owner, recipient, escrow_secret) =
+        utils::setup(/* with_account_contracts */ true);
 
     env.impersonate(escrow_address);
     let owner_note: AccountNote = utils::call_view_owner_note();

--- a/src/escrow_contract/src/test/leak_keys.nr
+++ b/src/escrow_contract/src/test/leak_keys.nr
@@ -1,10 +1,11 @@
-use crate::test::utils;
 use crate::Escrow;
+use crate::test::utils;
 
 #[test]
 unconstrained fn leak_keys_from_owner_to_recipient() {
-    let (env, escrow_address, owner, recipient, escrow_secret) = utils::setup(/* with_account_contracts */ true);
-    
+    let (env, escrow_address, owner, recipient, escrow_secret) =
+        utils::setup(/* with_account_contracts */ true);
+
     env.impersonate(owner);
     let leak_keys_call_interface = Escrow::at(escrow_address).leak_keys(recipient);
     leak_keys_call_interface.call(&mut env.private());
@@ -12,8 +13,9 @@ unconstrained fn leak_keys_from_owner_to_recipient() {
 
 #[test(should_fail_with = "Unauthorized")]
 unconstrained fn leak_keys_from_self() {
-    let (env, escrow_address, owner, recipient, escrow_secret) = utils::setup(/* with_account_contracts */ true);
-    
+    let (env, escrow_address, owner, recipient, escrow_secret) =
+        utils::setup(/* with_account_contracts */ true);
+
     env.impersonate(escrow_address);
     let leak_keys_call_interface = Escrow::at(escrow_address).leak_keys(recipient);
     leak_keys_call_interface.call(&mut env.private());
@@ -21,8 +23,9 @@ unconstrained fn leak_keys_from_self() {
 
 #[test(should_fail_with = "Unauthorized")]
 unconstrained fn leak_keys_from_recipient() {
-    let (env, escrow_address, owner, recipient, escrow_secret) = utils::setup(/* with_account_contracts */ true);
-    
+    let (env, escrow_address, owner, recipient, escrow_secret) =
+        utils::setup(/* with_account_contracts */ true);
+
     env.impersonate(recipient);
     let leak_keys_call_interface = Escrow::at(escrow_address).leak_keys(recipient);
     leak_keys_call_interface.call(&mut env.private());

--- a/src/escrow_contract/src/test/utils.nr
+++ b/src/escrow_contract/src/test/utils.nr
@@ -1,11 +1,11 @@
 use crate::Escrow;
 use crate::types::account_note::AccountNote;
+use dep::token::test::utils as token_utils;
 use aztec::{
     note::{constants::MAX_NOTES_PER_PAGE, note_getter::view_notes},
     prelude::{AztecAddress, NoteViewerOptions},
     test::helpers::{cheatcodes, test_environment::TestEnvironment},
 };
-use dep::token::test::utils as token_utils;
 
 pub unconstrained fn setup(
     with_account_contracts: bool,
@@ -52,11 +52,7 @@ pub unconstrained fn setup_and_mint(
     env.impersonate(owner);
     token_utils::mint_to_private(env, token_contract_address, escrow_address, mint_amount);
 
-    token_utils::check_private_balance(
-        token_contract_address,
-        escrow_address,
-        mint_amount,
-    );
+    token_utils::check_private_balance(token_contract_address, escrow_address, mint_amount);
 
     dep::aztec::oracle::debug_log::debug_log_format(
         "TOKEN ADDRESS: {0}",

--- a/src/escrow_contract/src/test/utils.nr
+++ b/src/escrow_contract/src/test/utils.nr
@@ -2,15 +2,10 @@ use crate::Escrow;
 use crate::types::account_note::AccountNote;
 use dep::token::Token;
 use aztec::{
-    oracle::{
-        execution::{get_contract_address},
-    },
+    note::{constants::MAX_NOTES_PER_PAGE, note_getter::view_notes},
+    oracle::execution::get_contract_address,
     prelude::{AztecAddress, NoteViewerOptions},
     test::helpers::{cheatcodes, test_environment::TestEnvironment},
-    note::{
-        note_getter::{view_notes},
-        constants::MAX_NOTES_PER_PAGE,
-    },
 };
 use std::test::OracleMock;
 
@@ -34,8 +29,7 @@ pub unconstrained fn setup(
     // Deploy escrow contract
     let escrow_secret = 42069;
     let escrow_contract_account = cheatcodes::add_account(escrow_secret);
-    let initializer_call_escrow =
-        Escrow::interface().constructor(owner, escrow_secret);
+    let initializer_call_escrow = Escrow::interface().constructor(owner, escrow_secret);
 
     let escrow_contract = env
         .deploy_self_with_public_keys("Escrow", escrow_secret)
@@ -52,7 +46,7 @@ pub unconstrained fn setup_and_mint(
     mint_amount: U128,
 ) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress, AztecAddress, Field) {
     let (env, escrow_address, owner, recipient, escrow_secret) = setup(with_account_contracts);
-    
+
     // Deploy token contract
     let initializer_call_interface = Token::interface().constructor(
         "TestToken0000000000000000000000",

--- a/src/escrow_contract/src/test/withdraw.nr
+++ b/src/escrow_contract/src/test/withdraw.nr
@@ -1,13 +1,15 @@
-use crate::test::utils;
 use crate::Escrow;
+use crate::test::utils;
 
 #[test]
 unconstrained fn withdraw_from_owner_to_recipient() {
     let mint_amount = U128::from_integer(1_000_000_000);
-    let (env, escrow_address, owner, recipient, token_address, escrow_secret) = utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
+    let (env, escrow_address, owner, recipient, token_address, escrow_secret) =
+        utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
 
     env.impersonate(owner);
-    let withdraw_call_interface = Escrow::at(escrow_address).withdraw(token_address, mint_amount, recipient);
+    let withdraw_call_interface =
+        Escrow::at(escrow_address).withdraw(token_address, mint_amount, recipient);
     withdraw_call_interface.call(&mut env.private());
 
     utils::check_private_balance(token_address, recipient, mint_amount);
@@ -17,18 +19,21 @@ unconstrained fn withdraw_from_owner_to_recipient() {
 #[test]
 unconstrained fn withdraw_twice() {
     let mint_amount = U128::from_integer(1_000_000_000);
-    let (env, escrow_address, owner, recipient, token_address, escrow_secret) = utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
+    let (env, escrow_address, owner, recipient, token_address, escrow_secret) =
+        utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
 
     env.impersonate(owner);
     let half_amount = U128::from_integer(500_000_000);
-    let withdraw_call_interface = Escrow::at(escrow_address).withdraw(token_address, half_amount, recipient);
+    let withdraw_call_interface =
+        Escrow::at(escrow_address).withdraw(token_address, half_amount, recipient);
     withdraw_call_interface.call(&mut env.private());
 
     utils::check_private_balance(token_address, recipient, half_amount);
     utils::check_private_balance(token_address, escrow_address, half_amount);
 
     // Second withdrawal
-    let withdraw_call_interface = Escrow::at(escrow_address).withdraw(token_address, half_amount, recipient);
+    let withdraw_call_interface =
+        Escrow::at(escrow_address).withdraw(token_address, half_amount, recipient);
     withdraw_call_interface.call(&mut env.private());
 
     utils::check_private_balance(token_address, recipient, mint_amount);
@@ -38,12 +43,14 @@ unconstrained fn withdraw_twice() {
 #[test]
 unconstrained fn withdraw_to_multiple_recipients() {
     let mint_amount = U128::from_integer(1_000_000_000);
-    let (env, escrow_address, owner, recipient, token_address, escrow_secret) = utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
+    let (env, escrow_address, owner, recipient, token_address, escrow_secret) =
+        utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
 
     env.impersonate(owner);
     let half_amount = U128::from_integer(500_000_000);
     let recipient1 = recipient;
-    let withdraw_call_interface = Escrow::at(escrow_address).withdraw(token_address, half_amount, recipient1);
+    let withdraw_call_interface =
+        Escrow::at(escrow_address).withdraw(token_address, half_amount, recipient1);
     withdraw_call_interface.call(&mut env.private());
 
     utils::check_private_balance(token_address, recipient1, half_amount);
@@ -51,7 +58,8 @@ unconstrained fn withdraw_to_multiple_recipients() {
 
     // Second withdrawal
     let recipient2 = owner;
-    let withdraw_call_interface = Escrow::at(escrow_address).withdraw(token_address, half_amount, recipient2);
+    let withdraw_call_interface =
+        Escrow::at(escrow_address).withdraw(token_address, half_amount, recipient2);
     withdraw_call_interface.call(&mut env.private());
 
     utils::check_private_balance(token_address, recipient1, half_amount);
@@ -62,20 +70,24 @@ unconstrained fn withdraw_to_multiple_recipients() {
 #[test(should_fail_with = "Unauthorized")]
 unconstrained fn withdraw_from_self() {
     let mint_amount = U128::from_integer(1_000_000_000);
-    let (env, escrow_address, owner, recipient, token_address, escrow_secret) = utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
-    
+    let (env, escrow_address, owner, recipient, token_address, escrow_secret) =
+        utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
+
     env.impersonate(escrow_address);
-    let withdraw_call_interface = Escrow::at(escrow_address).withdraw(token_address, mint_amount, recipient);
+    let withdraw_call_interface =
+        Escrow::at(escrow_address).withdraw(token_address, mint_amount, recipient);
     withdraw_call_interface.call(&mut env.private());
 }
 
 #[test(should_fail_with = "Unauthorized")]
 unconstrained fn withdraw_from_recipient() {
     let mint_amount = U128::from_integer(1_000_000_000);
-    let (env, escrow_address, owner, recipient, token_address, escrow_secret) = utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
-    
+    let (env, escrow_address, owner, recipient, token_address, escrow_secret) =
+        utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
+
     env.impersonate(recipient);
-    let withdraw_call_interface = Escrow::at(escrow_address).withdraw(token_address, mint_amount, recipient);
+    let withdraw_call_interface =
+        Escrow::at(escrow_address).withdraw(token_address, mint_amount, recipient);
     withdraw_call_interface.call(&mut env.private());
 }
 
@@ -84,9 +96,14 @@ unconstrained fn withdraw_from_recipient() {
 #[test(should_fail)]
 unconstrained fn recipient_cannot_withdraw_more_than_escrowed_amount() {
     let mint_amount = U128::from_integer(1_000_000_000);
-    let (env, escrow_address, owner, recipient, token_address, escrow_secret) = utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
+    let (env, escrow_address, owner, recipient, token_address, escrow_secret) =
+        utils::setup_and_mint(/* with_account_contracts */ true, mint_amount);
 
     env.impersonate(owner);
-    let withdraw_call_interface = Escrow::at(escrow_address).withdraw(token_address, mint_amount + U128::from_integer(1), recipient);
+    let withdraw_call_interface = Escrow::at(escrow_address).withdraw(
+        token_address,
+        mint_amount + U128::from_integer(1),
+        recipient,
+    );
     withdraw_call_interface.call(&mut env.private());
 }

--- a/src/token_contract/src/test/transfer_private_to_private.nr
+++ b/src/token_contract/src/test/transfer_private_to_private.nr
@@ -1,8 +1,8 @@
 use crate::test::utils;
 use crate::Token;
 use authwit::cheatcodes as authwit_cheatcodes;
-use uint_note::uint_note::UintNote;
 use aztec::note::constants::MAX_NOTES_PER_PAGE;
+use uint_note::uint_note::UintNote;
 
 #[test]
 unconstrained fn transfer_private_on_behalf_of_other() {

--- a/src/token_contract/src/test/transfer_private_to_public.nr
+++ b/src/token_contract/src/test/transfer_private_to_public.nr
@@ -1,11 +1,8 @@
 use crate::test::utils;
 use crate::Token;
 use authwit::cheatcodes as authwit_cheatcodes;
+use aztec::{note::constants::MAX_NOTES_PER_PAGE, oracle::random::random};
 use uint_note::uint_note::UintNote;
-use aztec::{
-    note::constants::MAX_NOTES_PER_PAGE,
-    oracle::random::random,
-};
 
 #[test]
 unconstrained fn transfer_private_to_public_on_behalf_of_self() {
@@ -103,11 +100,7 @@ unconstrained fn transfer_private_to_public_multiple_notes_recursively() {
         owner,
         total_amount - transfer_amount,
     );
-    utils::check_public_balance(
-        token_contract_address,
-        recipient,
-        transfer_amount,
-    );
+    utils::check_public_balance(token_contract_address, recipient, transfer_amount);
 }
 
 #[test(should_fail)]

--- a/src/ts/test/clawback.test.ts
+++ b/src/ts/test/clawback.test.ts
@@ -42,7 +42,7 @@ describe('Clawback - Multi PXE', () => {
 
     await bob.registerSender(alice.getAddress());
     // TODO: why do I need to register Alice's account?
-    await bob.registerAccount(aliceWallet.getSecretKey(), await alice.getCompleteAddress().partialAddress);
+    // await bob.registerAccount(aliceWallet.getSecretKey(), await alice.getCompleteAddress().partialAddress);
 
     console.log({
       alice: alice.getAddress(),

--- a/src/ts/test/clawback.test.ts
+++ b/src/ts/test/clawback.test.ts
@@ -14,7 +14,7 @@ import {
 } from './utils.js';
 import { deployToken } from './token.test.js';
 
-describe('ClawbackEscrow - Multi PXE', () => {
+describe('Clawback - Multi PXE', () => {
   let alicePXE: PXE;
   let bobPXE: PXE;
 

--- a/src/ts/test/escrow.test.ts
+++ b/src/ts/test/escrow.test.ts
@@ -44,7 +44,7 @@ describe('Escrow - Multi PXE', () => {
     await alicePXE.registerContract(token);
     await bobPXE.registerContract(token);
 
-    escrow = await deployEscrow([alicePXE, bobPXE], alice, bob.getAddress());
+    escrow = await deployEscrow(alice, bob.getAddress());
 
     // alice and bob know the escrow contract
     await alicePXE.registerContract(escrow);

--- a/src/ts/test/escrow.test.ts
+++ b/src/ts/test/escrow.test.ts
@@ -1,8 +1,8 @@
-import { TokenContractArtifact, TokenContract } from '../../artifacts/Token.js';
-import { EscrowContractArtifact, EscrowContract, EscrowKeys } from '../../artifacts/Escrow.js';
-import { AccountWallet, PXE, Logger, AccountWalletWithSecretKey, Fr, FunctionSelector } from '@aztec/aztec.js';
+import { TokenContract } from '../../artifacts/Token.js';
+import { EscrowContract, EscrowKeys } from '../../artifacts/Escrow.js';
+import { AccountWallet, PXE, Logger, AccountWalletWithSecretKey, Fr } from '@aztec/aztec.js';
 import { createAccount } from '@aztec/accounts/testing';
-import { createPXE, deployEscrow, expectAccountNote, expectTokenBalances, expectUintNote, wad } from './utils.js';
+import { createPXE, deployEscrow, expectAccountNote, expectTokenBalances, wad } from './utils.js';
 import { deployToken } from './token.test.js';
 
 describe('Escrow - Multi PXE', () => {

--- a/src/ts/test/token.test.ts
+++ b/src/ts/test/token.test.ts
@@ -8,15 +8,14 @@ import {
   TxStatus,
   getContractInstanceFromDeployParams,
   Contract,
-  AztecAddress,
   AccountWalletWithSecretKey,
 } from '@aztec/aztec.js';
 import { createAccount, getInitialTestAccountsWallets } from '@aztec/accounts/testing';
-import { AMOUNT, createPXE, expectTokenBalances, expectUintNote, logger, setupSandbox, wad } from './utils.js';
+import { AMOUNT, createPXE, expectTokenBalances, expectUintNote, setupSandbox, wad } from './utils.js';
 
 export async function deployToken(deployer: AccountWallet) {
   const contract = await Contract.deploy(deployer, TokenContractArtifact, ['PrivateToken', 'PT', 18]).send().deployed();
-  return contract;
+  return contract as TokenContract;
 }
 
 describe('Token - Single PXE', () => {


### PR DESCRIPTION
I'm re-enabling the call to `Escrow::leak_keys` and have modified the E2E tests so that Bob can claim the escrow's tokens without cheating (i.e., without manually passing it), but instead by retrieving the secret from the private log emitted by the contract.

The `nullification_secret` in the `EscrowKeys` event is not currently used, but I'm keeping it for now to explore potential future use cases