### PR TITLE
fix: mint_to_private iface (using from)

### DIFF
--- a/src/token_contract/src/main.nr
+++ b/src/token_contract/src/main.nr
@@ -271,12 +271,11 @@ pub contract Token {
 
     #[private]
     fn mint_to_private(from: AztecAddress, to: AztecAddress, amount: u128) {
-        let minter = storage.minter.read();
-        _validate_minter(context.msg_sender(), minter);
+        _validate_minter(context.msg_sender(), storage.minter.read());
 
         // We prepare the commitment to which we'll "send" the minted amount.
         let commitment =
-            _initialize_transfer_commitment(&mut context, storage.private_balances, minter, to);
+            _initialize_transfer_commitment(&mut context, storage.private_balances, from, to);
 
         Token::at(context.this_address()).mint_to_commitment_internal(amount, commitment).enqueue(
             &mut context,


### PR DESCRIPTION
When "minting to private", the minter is possibly a dumb-contract, a contract w/o encryption secrets. When minting "to private", we need an encryption secret in order to do the DH handshake and encrypt the log.

This change allows the dumb-contract (that holds as `msg_sender` the permission to call `mint`) to input an arbitrary sender for the minted note.