### PR TITLE
test: unskip ts tests

### DIFF
--- a/src/ts/test/token.test.ts
+++ b/src/ts/test/token.test.ts
@@ -179,24 +179,24 @@ describe('Token - Single PXE', () => {
   }, 300_000);
 
   // TODO(#29): burn was nuked because of this PR, re-enable it
-  // it('burns public tokens', async () => {
-  //   // First mint 2 tokens to alice
-  //   await token
-  //     .withWallet(alice)
-  //     .methods.mint_to_public(alice.getAddress(), AMOUNT * 2n)
-  //     .send()
-  //     .wait();
+  it('burns public tokens', async () => {
+    // First mint 2 tokens to alice
+    await token
+      .withWallet(alice)
+      .methods.mint_to_public(alice.getAddress(), AMOUNT * 2n)
+      .send()
+      .wait();
 
-  //   // Burn 1 token from alice
-  //   await token.withWallet(alice).methods.burn_public(alice.getAddress(), AMOUNT, 0).send().wait();
+    // Burn 1 token from alice
+    await token.withWallet(alice).methods.burn_public(alice.getAddress(), AMOUNT, 0).send().wait();
 
-  //   // Check balance and total supply are reduced
-  //   const aliceBalance = await token.methods.balance_of_public(alice.getAddress()).simulate();
-  //   const totalSupply = await token.methods.total_supply().simulate();
+    // Check balance and total supply are reduced
+    const aliceBalance = await token.methods.balance_of_public(alice.getAddress()).simulate();
+    const totalSupply = await token.methods.total_supply().simulate();
 
-  //   expect(aliceBalance).toBe(AMOUNT);
-  //   expect(totalSupply).toBe(AMOUNT);
-  // }, 300_000);
+    expect(aliceBalance).toBe(AMOUNT);
+    expect(totalSupply).toBe(AMOUNT);
+  }, 300_000);
 
   it('transfers tokens from private to public balance', async () => {
     // First mint to private 2 tokens to alice
@@ -236,19 +236,17 @@ describe('Token - Single PXE', () => {
     ).rejects.toThrow(/invalid nonce/);
   }, 300_000);
 
-  it.skip('fails when transferring more tokens than available in private balance', async () => {
-    // Mint 1 token privately to alice
+  it('fails when transferring more tokens than available in private balance', async () => {
     await token.withWallet(alice).methods.mint_to_private(alice.getAddress(), alice.getAddress(), AMOUNT).send().wait();
 
     // Try to transfer more tokens than available from private to public balance
-    // TODO(#29): fix "Invalid arguments size: expected 3, got 2" error handling
-    // await expect(
-    //   token
-    //     .withWallet(alice)
-    //     .methods.transfer_private_to_public(alice.getAddress(), alice.getAddress(), AMOUNT + 1n, 0)
-    //     .send()
-    //     .wait(),
-    // ).rejects.toThrow(/Balance too low/);
+    await expect(
+      token
+        .withWallet(alice)
+        .methods.transfer_private_to_public(alice.getAddress(), alice.getAddress(), AMOUNT + 1n, 0)
+        .send()
+        .wait(),
+    ).rejects.toThrow(/balance too low/);
   }, 300_000);
 
   it('can transfer tokens between private balances', async () => {
@@ -268,13 +266,13 @@ describe('Token - Single PXE', () => {
 
     // Try to transfer more than available balance
     // TODO(#29): fix "Invalid arguments size: expected 3, got 2" error handling
-    // await expect(
-    //   token
-    //     .withWallet(alice)
-    //     .methods.transfer_private_to_private(alice.getAddress(), bob.getAddress(), AMOUNT + 1n, 0)
-    //     .send()
-    //     .wait(),
-    // ).rejects.toThrow(/Balance too low/);
+    await expect(
+      token
+        .withWallet(alice)
+        .methods.transfer_private_to_private(alice.getAddress(), bob.getAddress(), AMOUNT + 1n, 0)
+        .send()
+        .wait(),
+    ).rejects.toThrow(/balance too low/);
 
     // Check total supply hasn't changed
     const totalSupply = await token.methods.total_supply().simulate();
@@ -299,34 +297,34 @@ describe('Token - Single PXE', () => {
   }, 300_000);
 
   // TODO(#29): burn was nuked because of this PR, re-enable it
-  // it('can burn tokens from private balance', async () => {
-  //   // Mint 2 tokens privately to alice
-  //   await token
-  //     .withWallet(alice)
-  //     .methods.mint_to_private(alice.getAddress(), alice.getAddress(), AMOUNT * 2n)
-  //     .send()
-  //     .wait();
+  it('can burn tokens from private balance', async () => {
+    // Mint 2 tokens privately to alice
+    await token
+      .withWallet(alice)
+      .methods.mint_to_private(alice.getAddress(), alice.getAddress(), AMOUNT * 2n)
+      .send()
+      .wait();
 
-  //   // Burn 1 token from alice's private balance
-  //   await token.withWallet(alice).methods.burn_private(alice.getAddress(), AMOUNT, 0).send().wait();
+    // Burn 1 token from alice's private balance
+    await token.withWallet(alice).methods.burn_private(alice.getAddress(), AMOUNT, 0).send().wait();
 
-  //   // Try to burn more than available balance
-  //   await expect(
-  //     token
-  //       .withWallet(alice)
-  //       .methods.burn_private(alice.getAddress(), AMOUNT * 2n, 0)
-  //       .send()
-  //       .wait(),
-  //   ).rejects.toThrow(/Balance too low/);
+    // Try to burn more than available balance
+    await expect(
+      token
+        .withWallet(alice)
+        .methods.burn_private(alice.getAddress(), AMOUNT * 2n, 0)
+        .send()
+        .wait(),
+    ).rejects.toThrow(/Balance too low/);
 
-  //   // Check total supply decreased
-  //   const totalSupply = await token.methods.total_supply().simulate();
-  //   expect(totalSupply).toBe(AMOUNT);
+    // Check total supply decreased
+    const totalSupply = await token.methods.total_supply().simulate();
+    expect(totalSupply).toBe(AMOUNT);
 
-  //   // Public balance should still be 0
-  //   const alicePublicBalance = await token.methods.balance_of_public(alice.getAddress()).simulate();
-  //   expect(alicePublicBalance).toBe(0n);
-  // }, 300_000);
+    // Public balance should still be 0
+    const alicePublicBalance = await token.methods.balance_of_public(alice.getAddress()).simulate();
+    expect(alicePublicBalance).toBe(0n);
+  }, 300_000);
 
   it('can transfer tokens from public to private balance', async () => {
     // Mint 2 tokens publicly to alice
@@ -377,26 +375,30 @@ describe('Token - Single PXE', () => {
     expect(await token.methods.total_supply().simulate()).toBe(AMOUNT);
 
     // alice prepares partial note for bob
-    await token.methods.initialize_transfer_commitment(bob.getAddress(), alice.getAddress()).send().wait();
+    const initTx = await token.methods.initialize_transfer_commitment(bob.getAddress(), bob.getAddress()).send().wait();
+    const initTxEffect = await pxe.getTxEffect(initTx.txHash);
+    console.log(initTxEffect);
 
     // alice still has tokens in public
     expect(await token.methods.balance_of_public(alice.getAddress()).simulate()).toBe(AMOUNT);
 
+    console.log(initTxEffect!.data!.publicDataWrites);
+    // const commitment = new Fr(initTxEffect!.data!.publicDataWrites![0].leafSlot as bigint);
+    const commitment = initTxEffect!.data!.publicDataWrites![0].leafSlot;
+
     // finalize partial note passing the commitment slot
-    // await token.methods.transfer_public_to_commitment(AMOUNT, latestEvent.hiding_point_slot).send().wait();
+    await token.methods.transfer_public_to_commitment(alice.getAddress(), AMOUNT, { commitment }, 0).send().wait();
 
     // alice now has no tokens
     // expect(await token.methods.balance_of_public(alice.getAddress()).simulate()).toBe(0n);
-    // // bob has tokens in private
+    // bob has tokens in private
     // expect(await token.methods.balance_of_public(bob.getAddress()).simulate()).toBe(0n);
     // expect(await token.methods.balance_of_private(bob.getAddress()).simulate()).toBe(AMOUNT);
-    // // total supply is still the same
-    // expect(await token.methods.total_supply().simulate()).toBe(AMOUNT);
+    // total supply is still the same
+    expect(await token.methods.total_supply().simulate()).toBe(AMOUNT);
   }, 300_000);
 
-  // TODO: Can't figure out why this is failing
-  // Assertion failed: unauthorized 'true, authorized'
-  it.skip('public transfer with authwitness', async () => {
+  it('public transfer with authwitness', async () => {
     // Mint tokens to Alice in public
     await token.withWallet(alice).methods.mint_to_public(alice.getAddress(), AMOUNT).send().wait();
 

--- a/src/ts/test/token.test.ts
+++ b/src/ts/test/token.test.ts
@@ -246,7 +246,7 @@ describe('Token - Single PXE', () => {
         .methods.transfer_private_to_public(alice.getAddress(), alice.getAddress(), AMOUNT + 1n, 0)
         .send()
         .wait(),
-    ).rejects.toThrow(/balance too low/);
+    ).rejects.toThrow(/Balance too low/);
   }, 300_000);
 
   it('can transfer tokens between private balances', async () => {
@@ -272,7 +272,7 @@ describe('Token - Single PXE', () => {
         .methods.transfer_private_to_private(alice.getAddress(), bob.getAddress(), AMOUNT + 1n, 0)
         .send()
         .wait(),
-    ).rejects.toThrow(/balance too low/);
+    ).rejects.toThrow(/Balance too low/);
 
     // Check total supply hasn't changed
     const totalSupply = await token.methods.total_supply().simulate();

--- a/src/ts/test/token.test.ts
+++ b/src/ts/test/token.test.ts
@@ -178,7 +178,6 @@ describe('Token - Single PXE', () => {
     expect(bobBalance).toBe(AMOUNT);
   }, 300_000);
 
-  // TODO(#29): burn was nuked because of this PR, re-enable it
   it('burns public tokens', async () => {
     // First mint 2 tokens to alice
     await token
@@ -265,7 +264,6 @@ describe('Token - Single PXE', () => {
       .wait();
 
     // Try to transfer more than available balance
-    // TODO(#29): fix "Invalid arguments size: expected 3, got 2" error handling
     await expect(
       token
         .withWallet(alice)
@@ -296,7 +294,6 @@ describe('Token - Single PXE', () => {
     expect(alicePublicBalance).toBe(0n);
   }, 300_000);
 
-  // TODO(#29): burn was nuked because of this PR, re-enable it
   it('can burn tokens from private balance', async () => {
     // Mint 2 tokens privately to alice
     await token
@@ -341,15 +338,13 @@ describe('Token - Single PXE', () => {
       .send()
       .wait();
 
-    // Try to transfer more than available public balance
-    // TODO(#29): fix "Invalid arguments size: expected 3, got 2" error handling
-    // await expect(
-    //   token
-    //     .withWallet(alice)
-    //     .methods.transfer_public_to_private(alice.getAddress(), alice.getAddress(), AMOUNT * 2n, 0)
-    //     .send()
-    //     .wait(),
-    // ).rejects.toThrow(/attempt to subtract with underflow/);
+    await expect(
+      token
+        .withWallet(alice)
+        .methods.transfer_public_to_private(alice.getAddress(), alice.getAddress(), AMOUNT * 2n, 0)
+        .send()
+        .wait(),
+    ).rejects.toThrow(/attempt to subtract with underflow/);
 
     // Check total supply stayed the same
     const totalSupply = await token.methods.total_supply().simulate();


### PR DESCRIPTION
 Currently, we have some skipped ts tests so I'm reenabling all of them ~except one~.

~I'm still struggling to read _raw_ private logs (not events!) from the PXE.~ Leaving this one for a future PR.