### PR TITLE
ci: fix nested artifacts dir

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -71,7 +71,9 @@ jobs:
           mkdir -p export/${{ env.PROJECT_NAME }}/current/artifacts
           mkdir -p export/${{ env.PROJECT_NAME }}/historical
           
-          # Fix historical versions structure if they have double-nested artifacts
+          # This snippet copies the contents of the nested directory artifacts/artifacts
+          # and moves them up one level to artifacts/. Then it removes the now empty nested directory.
+          # After we run this once, this won't be needed anymore.
           if [ -d "node_modules/${{ env.PROJECT_NAME }}/historical" ]; then
             # First copy all historical versions
             cp -r node_modules/${{ env.PROJECT_NAME }}/historical/** export/${{ env.PROJECT_NAME }}/historical/

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -71,14 +71,27 @@ jobs:
           mkdir -p export/${{ env.PROJECT_NAME }}/current/artifacts
           mkdir -p export/${{ env.PROJECT_NAME }}/historical
           
+          # Fix historical versions structure if they have double-nested artifacts
           if [ -d "node_modules/${{ env.PROJECT_NAME }}/historical" ]; then
+            # First copy all historical versions
             cp -r node_modules/${{ env.PROJECT_NAME }}/historical/** export/${{ env.PROJECT_NAME }}/historical/
+            
+            # Fix structure for each historical version
+            for version_dir in export/${{ env.PROJECT_NAME }}/historical/*/; do
+              if [ -d "${version_dir}artifacts/artifacts" ]; then
+                echo "Fixing double-nested artifacts structure in ${version_dir}"
+                # Move contents up one level
+                mv "${version_dir}artifacts/artifacts"/* "${version_dir}artifacts/"
+                # Remove empty nested directory
+                rm -rf "${version_dir}artifacts/artifacts"
+              fi
+            done
           else
             echo "No historical directory found, skipping copy"
           fi
 
           # Copy the compiled JS files directly to artifacts directory
-          cp -r dist/* export/${{ env.PROJECT_NAME }}/current/artifacts
+          cp -r dist/* export/${{ env.PROJECT_NAME }}/current/artifacts/
           cp -r target export/${{ env.PROJECT_NAME }}/current/
 
           # Copy deployments.json if it exists

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           yarn
           yarn add @defi-wonderland/aztec-standards@canary
+
       - name: Compile
         run: yarn compile
 
@@ -50,8 +51,8 @@ jobs:
 
       - name: Compile artifacts to JS
         run: |
-          mkdir -p dist/artifacts
-          yarn tsc artifacts/*.ts --outDir dist/artifacts --skipLibCheck --target es2020 --module nodenext --moduleResolution nodenext --resolveJsonModule --declaration
+          mkdir -p dist/
+          yarn tsc artifacts/*.ts --outDir dist/ --skipLibCheck --target es2020 --module nodenext --moduleResolution nodenext --resolveJsonModule --declaration
 
       - name: Update version
         run: yarn version --new-version "0.0.0-${GITHUB_SHA::8}" --no-git-tag-version
@@ -67,7 +68,7 @@ jobs:
       - name: Prepare files for release
         run: |
           VERSION="0.0.0-${GITHUB_SHA::8}"
-          mkdir -p export/${{ env.PROJECT_NAME }}/current
+          mkdir -p export/${{ env.PROJECT_NAME }}/current/artifacts
           mkdir -p export/${{ env.PROJECT_NAME }}/historical
           
           if [ -d "node_modules/${{ env.PROJECT_NAME }}/historical" ]; then
@@ -76,7 +77,8 @@ jobs:
             echo "No historical directory found, skipping copy"
           fi
 
-          cp -r dist/artifacts export/${{ env.PROJECT_NAME }}/current/
+          # Copy the compiled JS files directly to artifacts directory
+          cp -r dist/* export/${{ env.PROJECT_NAME }}/current/artifacts
           cp -r target export/${{ env.PROJECT_NAME }}/current/
 
           # Copy deployments.json if it exists


### PR DESCRIPTION
The current releases have a double nested `artifacts/` dir. 
Check: https://www.npmjs.com/package/@defi-wonderland/aztec-standards/v/0.0.0-ed584f67?activeTab=code

