### PR TITLE
chore: add concurrency check to benchmark workflow

### DIFF
--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -3,6 +3,10 @@ name: Aztec Benchmark Diff
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
# 🤖 Linear

Closes AZT-228

## Description 

Added concurrency control to `.github/workflows/compare-benchmark.yml` to automatically cancel previous benchmark runs when new commits are pushed to PRs.

**Changes:**
- Added `concurrency` section with PR-specific grouping
- Enables `cancel-in-progress: true` to stop outdated runs

**Benefits:**
- Saves CI resources by avoiding redundant benchmark runs
- Faster feedback on latest commit changes
- Eliminates confusion from multiple benchmark results