### PR TITLE
chore: deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:nr": "aztec test",
     "lint:prettier": "prettier '**/*.{js,ts}' --write",
     "bench": "NODE_NO_WARNINGS=1 aztec-benchmark --suffix _base",
-    "ccc": "yarn clean && yarn compile && yarn codegen"
+    "ccc": "yarn clean && yarn compile && yarn codegen",
+    "deploy": "NODE_NO_WARNINGS=1 AZTEC_NODE_URL=http://localhost:8081 PXE_URL=http://localhost:8081 tsx src/ts/deploy.ts"
   },
   "lint-staged": {
     "*.ts": "prettier --write -u"
@@ -30,7 +31,7 @@
     "@aztec/noir-contracts.js": "0.87.8",
     "@aztec/protocol-contracts": "0.87.8",
     "@aztec/pxe": "0.87.8",
-    "@aztec/stdlib": "0.87.8",    
+    "@aztec/stdlib": "0.87.8",
     "@defi-wonderland/aztec-benchmark": "1.0.0",
     "@types/node": "22.5.1"
   },
@@ -44,6 +45,7 @@
     "prettier": "3.4.2",
     "ts-jest": "29.2.5",
     "ts-node": "10.9.2",
+    "tsx": "^4.20.3",
     "typescript": "5.7.2"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -20,17 +20,18 @@
     "lint:prettier": "prettier '**/*.{js,ts}' --write",
     "bench": "NODE_NO_WARNINGS=1 aztec-benchmark --suffix _base",
     "ccc": "yarn clean && yarn compile && yarn codegen",
-    "deploy": "NODE_NO_WARNINGS=1 AZTEC_NODE_URL=http://localhost:8081 PXE_URL=http://localhost:8081 tsx src/ts/deploy.ts"
+    "deploy:sandbox": "NODE_NO_WARNINGS=1 AZTEC_NODE_URL=http://localhost:8080 PXE_URL=http://localhost:8080 tsx src/ts/deploy.ts",
+    "deploy:testnet": "NODE_NO_WARNINGS=1 AZTEC_NODE_URL=http://localhost:8081 PXE_URL=http://localhost:8081 tsx src/ts/deploy.ts"
   },
   "lint-staged": {
     "*.ts": "prettier --write -u"
   },
   "dependencies": {
-    "@aztec/accounts": "0.87.8",
-    "@aztec/aztec.js": "0.87.8",
-    "@aztec/noir-contracts.js": "0.87.8",
-    "@aztec/protocol-contracts": "0.87.8",
-    "@aztec/pxe": "0.87.8",
+    "@aztec/accounts": "0.87.9",
+    "@aztec/aztec.js": "0.87.9",
+    "@aztec/noir-contracts.js": "0.87.9",
+    "@aztec/protocol-contracts": "0.87.9",
+    "@aztec/pxe": "0.87.9",
     "@aztec/stdlib": "0.87.8",
     "@defi-wonderland/aztec-benchmark": "1.0.0",
     "@types/node": "22.5.1"

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -1,0 +1,356 @@
+import {
+  AccountWallet,
+  AccountWalletWithSecretKey,
+  AztecAddress,
+  Contract,
+  ContractBase,
+  createLogger,
+  createPXEClient,
+  DeployOptions,
+  Fr,
+  getContractInstanceFromDeployParams,
+  PXE,
+  sleep,
+  waitForPXE,
+  WaitOpts,
+} from '@aztec/aztec.js';
+import { SponsoredFeePaymentMethod } from '@aztec/aztec.js/fee/testing';
+import { getUnsafeSchnorrAccount } from '@aztec/accounts/single_key';
+import { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
+import { SPONSORED_FPC_SALT } from '@aztec/constants';
+import { type UserFeeOptions } from '@aztec/entrypoints/interfaces';
+import { poseidon2Hash, poseidon2HashWithSeparator } from '@aztec/foundation/crypto';
+import { TokenContract, TokenContractArtifact } from '../artifacts/Token.js';
+import { DripperContract, DripperContractArtifact } from '../artifacts/Dripper.js';
+
+const amt = (n: number = 1, decimals: number = 1) => {
+  return BigInt(n * 10 ** decimals);
+};
+
+const logger = createLogger('aztec:deploy');
+
+interface DeployedContracts {
+  weth?: TokenContract;
+  dai?: TokenContract;
+  usdc?: TokenContract;
+  dripper?: DripperContract;
+  deployer?: AccountWalletWithSecretKey;
+}
+
+// const DRIPPER_ADDRESS = '0x2460b20e4a0ded84818a28cfc04448dc702c80188a36662258e256dd9854564b'
+const DRIPPER_ADDRESS = '';
+const DEPLOYER_SECRET = await poseidon2Hash([
+  Fr.fromBufferReduce(Buffer.from('a highly secret string padpadpad', 'utf8')),
+]);
+
+const defaultWaitOptions: WaitOpts = {
+  timeout: 600,
+};
+
+export function logDeployedContracts(contracts: DeployedContracts): void {
+  logger.info('Deployed contracts:');
+
+  for (const [key, value] of Object.entries(contracts)) {
+    if (value instanceof ContractBase) {
+      console.log(`${key}: ${value?.address.toString()}`);
+    } else {
+      console.log(`${key}: ${value}`);
+    }
+  }
+}
+
+export interface TokenDeployParams {
+  name: string;
+  symbol: string;
+  decimals: number;
+  minter?: AztecAddress;
+  upgradeAuthority?: AztecAddress;
+}
+
+export async function setupPXE(): Promise<PXE> {
+  const pxeUrl = process.env.PXE_URL || 'http://localhost:8081';
+  logger.info(`Setting up PXE to ${pxeUrl}...`);
+  const pxe = createPXEClient(pxeUrl);
+
+  try {
+    await waitForPXE(pxe, logger);
+    logger.info('Connected to PXE');
+
+    const nodeInfo = await pxe.getNodeInfo();
+    logger.info(`Connected to Aztec node version: ${nodeInfo.nodeVersion}`);
+
+    return pxe;
+  } catch (error) {
+    logger.error('Failed to connect to PXE:', error);
+    throw error;
+  }
+}
+
+export async function createAccount(pxe: PXE): Promise<AccountWalletWithSecretKey> {
+  logger.info('Creating account...');
+
+  // const contracts = await pxe.getContracts();
+  // console.log(contracts.map(c => c.toString()));
+  // let accounts = await pxe.getRegisteredAccounts();
+  // console.log(accounts.map(a => a.toString()));
+
+  let secret: Fr;
+  if (!DEPLOYER_SECRET) {
+    console.log('No DEPLOYER_SECRET found, generating random secret');
+    secret = Fr.random();
+    console.log(`Random secret: ${secret.toString()}`);
+  } else {
+    console.log('Using DEPLOYER_SECRET');
+    secret = DEPLOYER_SECRET;
+  }
+  // const secret = DEPLOYER_SECRET || Fr.random();
+  const manager = await getUnsafeSchnorrAccount(pxe, secret, Fr.ZERO);
+  const wallet = await manager.register();
+
+  // accounts = await pxe.getRegisteredAccounts();
+  // console.log(accounts.map(a => a.toString()));
+
+  logger.info(`Account created: ${wallet.getAddress().toString()}`);
+  return wallet;
+}
+
+export async function createSponsoredFeeOptions(pxe: PXE): Promise<UserFeeOptions> {
+  logger.info('Setting up sponsored fee options...');
+
+  const sponsoredFPCInstance = await getContractInstanceFromDeployParams(SponsoredFPCContract.artifact, {
+    salt: new Fr(SPONSORED_FPC_SALT),
+  });
+
+  try {
+    await pxe.registerContract({
+      instance: sponsoredFPCInstance,
+      artifact: SponsoredFPCContract.artifact,
+    });
+    logger.info(`Registered SponsoredFPC at: ${sponsoredFPCInstance.address.toString()}`);
+  } catch (error) {
+    logger.debug('SponsoredFPC already registered');
+  }
+
+  const paymentMethod = new SponsoredFeePaymentMethod(sponsoredFPCInstance.address);
+
+  return {
+    paymentMethod,
+    estimateGas: true,
+  };
+}
+
+export async function deployToken(
+  deployer: AccountWallet,
+  params: TokenDeployParams,
+  options: DeployOptions,
+): Promise<TokenContract> {
+  logger.info(`Deploying Token: ${params.name} (${params.symbol})`);
+  console.log(params);
+  const minter = params.minter || deployer.getAddress();
+  const upgradeAuthority = params.upgradeAuthority || AztecAddress.ZERO;
+
+  const contract = await Contract.deploy(
+    deployer,
+    TokenContractArtifact,
+    [params.name, params.symbol, params.decimals, minter, upgradeAuthority],
+    'constructor_with_minter',
+  )
+    .send(options)
+    .deployed(defaultWaitOptions);
+
+  const tokenContract = await TokenContract.at(contract.address, deployer);
+  logger.info(`Token deployed at: ${contract.address.toString()}`);
+
+  return tokenContract;
+}
+
+export async function deployDefaultToken(
+  pxe: PXE,
+  deployer: AccountWallet,
+  name: string = 'Private Token',
+  symbol: string = 'PT',
+  decimals: number = 18,
+  options?: DeployOptions,
+): Promise<TokenContract> {
+  const sponsoredFeeOptions = await createSponsoredFeeOptions(pxe);
+
+  const deployOptions: DeployOptions = {
+    fee: sponsoredFeeOptions,
+    universalDeploy: true,
+    ...options,
+  };
+
+  const tokenParams: TokenDeployParams = {
+    name,
+    symbol,
+    decimals,
+    minter: deployer.getAddress(),
+    upgradeAuthority: AztecAddress.ZERO,
+  };
+
+  return deployToken(deployer, tokenParams, deployOptions);
+}
+
+export async function deployDripper(deployer: AccountWallet, options: DeployOptions): Promise<DripperContract> {
+  logger.info('Deploying Dripper contract...');
+
+  const contract = await Contract.deploy(deployer, DripperContractArtifact, [], 'constructor')
+    .send(options)
+    .deployed(defaultWaitOptions);
+
+  const dripperContract = await DripperContract.at(contract.address, deployer);
+  logger.info(`Dripper deployed at: ${contract.address.toString()}`);
+  await sleep(24000);
+  return dripperContract;
+}
+
+export async function dripToPublic(
+  dripper: DripperContract,
+  tokenAddress: AztecAddress,
+  amount: bigint,
+  fromWallet: AccountWallet,
+  options: DeployOptions,
+): Promise<void> {
+  logger.info(`Dripping ${amount} tokens to public balance for ${tokenAddress.toString()}`);
+
+  const dripperWithWallet = await DripperContract.at(dripper.address, fromWallet);
+
+  const tx = await dripperWithWallet.methods
+    .drip_to_public(tokenAddress, amount)
+    .send(options)
+    .wait(defaultWaitOptions);
+
+  logger.info(`Public drip completed, tx hash: ${tx.txHash.toString()}`);
+}
+
+export async function dripToPrivate(
+  dripper: DripperContract,
+  tokenAddress: AztecAddress,
+  amount: bigint,
+  fromWallet: AccountWallet,
+  options: DeployOptions,
+): Promise<void> {
+  logger.info(`Dripping ${amount} tokens to private balance for ${tokenAddress.toString()}`);
+
+  const dripperWithWallet = await DripperContract.at(dripper.address, fromWallet);
+
+  const sendOptions = options;
+  const waitOptions = defaultWaitOptions;
+
+  const tx = await dripperWithWallet.methods.drip_to_private(tokenAddress, amount).send(sendOptions).wait(waitOptions);
+
+  logger.info(`Private drip completed, tx hash: ${tx.txHash.toString()}`);
+}
+
+export async function deployToTestnet(): Promise<DeployedContracts> {
+  logger.info('Deploying to Aztec Testnet...');
+
+  try {
+    const pxe = await setupPXE();
+    const deployer = await createAccount(pxe);
+    const sponsoredFeeOptions = await createSponsoredFeeOptions(pxe);
+
+    const deployOptions: DeployOptions = {
+      fee: sponsoredFeeOptions,
+      universalDeploy: true,
+    };
+
+    logger.info(`Deploying with account: ${deployer.getAddress().toString()}`);
+
+    // Deploy dripper first, as it will be the token's minter
+    let dripper: DripperContract;
+    if (DRIPPER_ADDRESS) {
+      logger.info(`Using existing dripper at ${DRIPPER_ADDRESS}`);
+      dripper = await DripperContract.at(AztecAddress.fromString(DRIPPER_ADDRESS), deployer);
+      logger.info(`Dripper at: ${dripper.address.toString()}`);
+      try {
+        await pxe.registerContract({
+          instance: dripper.instance,
+          artifact: DripperContractArtifact,
+        });
+      } catch (error) {
+        logger.debug('Dripper already registered');
+      }
+    } else {
+      dripper = await deployDripper(deployer, deployOptions);
+    }
+
+    // Deploy token with dripper as the minter
+    // const tokenParams: TokenDeployParams = {
+    //   name: 'Private Token',
+    //   symbol: 'PT',
+    //   decimals: 18,
+    //   minter: dripper.address,
+    //   upgradeAuthority: AztecAddress.ZERO,
+    // };
+
+    const weth = await deployToken(
+      deployer,
+      {
+        name: 'WETH',
+        symbol: 'WETH',
+        decimals: 18,
+        minter: dripper.address,
+        upgradeAuthority: AztecAddress.ZERO,
+      },
+      deployOptions,
+    );
+    await sleep(24000);
+    const dai = await deployToken(
+      deployer,
+      {
+        name: 'DAI',
+        symbol: 'DAI',
+        decimals: 9,
+        minter: dripper.address,
+        upgradeAuthority: AztecAddress.ZERO,
+      },
+      deployOptions,
+    );
+    const usdc = await deployToken(
+      deployer,
+      {
+        name: 'USDC',
+        symbol: 'USDC',
+        decimals: 6,
+        minter: dripper.address,
+        upgradeAuthority: AztecAddress.ZERO,
+      },
+      deployOptions,
+    );
+
+    await dripToPublic(dripper, weth.address, amt(1), deployer, deployOptions);
+    await dripToPublic(dripper, dai.address, amt(1000, 9), deployer, deployOptions);
+    await dripToPublic(dripper, usdc.address, amt(1000, 6), deployer, deployOptions);
+    await dripToPrivate(dripper, weth.address, amt(1), deployer, deployOptions);
+    await dripToPrivate(dripper, dai.address, amt(1000, 9), deployer, deployOptions);
+    await dripToPrivate(dripper, usdc.address, amt(1000, 6), deployer, deployOptions);
+
+    logger.info(`Token minter set to Dripper: ${dripper.address.toString()}`);
+
+    logger.info('Testnet deployment completed successfully!');
+
+    return {
+      weth,
+      dai,
+      usdc,
+      dripper,
+      deployer,
+    };
+  } catch (error) {
+    logger.error('Testnet deployment failed:', error);
+    throw error;
+  }
+}
+
+console.log('Deploying to testnet...');
+if (import.meta.url === `file://${process.argv[1]}`) {
+  deployToTestnet()
+    .then((contracts) => {
+      logDeployedContracts(contracts);
+    })
+    .catch((error) => {
+      logger.error('Deployment failed:', error);
+      process.exit(1);
+    });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5424,6 +5424,16 @@ tsx@^4.19.4:
   optionalDependencies:
     fsevents "~2.3.3"
 
+tsx@^4.20.3:
+  version "4.20.3"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.20.3.tgz#f913e4911d59ad177c1bcee19d1035ef8dd6e2fb"
+  integrity sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==
+  dependencies:
+    esbuild "~0.25.0"
+    get-tsconfig "^4.7.5"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
 tunnel@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,30 +43,30 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aztec/accounts@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-0.87.8.tgz#382dafa2d7375c2bdb26e958d251f8af0171c28f"
-  integrity sha512-fDxOEntA/4lV2gcdk9imsPuJ0DFQbs1HEHCInTJYlTHtwvYmHWc8DEGs+y/5UcljhLpbILYHox0xMxiBFcSTmg==
+"@aztec/accounts@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-0.87.9.tgz#4304da8a3abe78561c4f80c593d85bddc2f6d9c2"
+  integrity sha512-DRU6w9gQ/2vpk67t5zC4LPORjFxdjFL4hAhFbRw4vfdjX4IIspo3UK+niWD2Ef5nRYVxo1asrfNzid7pgEyJww==
   dependencies:
-    "@aztec/aztec.js" "0.87.8"
-    "@aztec/entrypoints" "0.87.8"
-    "@aztec/ethereum" "0.87.8"
-    "@aztec/foundation" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
+    "@aztec/aztec.js" "0.87.9"
+    "@aztec/entrypoints" "0.87.9"
+    "@aztec/ethereum" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-0.87.8.tgz#50e43fbecce9b6babd6ec8736301e42b83d6df7b"
-  integrity sha512-iPh13JMp9im6IHS37tAvkEsr5dkhIksBrDhWPIMxhxn5r0EQ0ApLcK2pHGAa8/gW4jgTgCXKoqnurrHVcbei3Q==
+"@aztec/aztec.js@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-0.87.9.tgz#de2a7093ddb23e73efbb5e3be1cb2e248b8ea9a9"
+  integrity sha512-1KFWBuQr3m1aFZkfdunDtA2wiyRTIFbBqwFg19pIuAwUzXMfkE9pxqaXNUjSQNyBkKK9mhfSeC3AsdPacYwhLg==
   dependencies:
-    "@aztec/constants" "0.87.8"
-    "@aztec/entrypoints" "0.87.8"
-    "@aztec/ethereum" "0.87.8"
-    "@aztec/foundation" "0.87.8"
-    "@aztec/l1-artifacts" "0.87.8"
-    "@aztec/protocol-contracts" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
+    "@aztec/constants" "0.87.9"
+    "@aztec/entrypoints" "0.87.9"
+    "@aztec/ethereum" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/l1-artifacts" "0.87.9"
+    "@aztec/protocol-contracts" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
     axios "^1.8.2"
     tslib "^2.4.0"
     viem "2.23.7"
@@ -87,21 +87,21 @@
     tslib "^2.4.0"
     viem "2.23.7"
 
-"@aztec/bb-prover@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-0.87.8.tgz#5c844faa393c580ae818a6fdb8adccccd337e114"
-  integrity sha512-Up2ItKLmPkH0UGKR6XbQKYYAmMNMS+aU1BbwlY/AKa1Ocgk+k9uCJOMTS+PB+rlyE0hW9F7LrxBim16HJ47zdA==
+"@aztec/bb-prover@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-0.87.9.tgz#f98a0f7cb9d0ca6eca27546cbe5e0c145b0a6f50"
+  integrity sha512-8yp4YOzEs6CLRoYdGHjgT4C1Kkuzah16EfZC1dAXg/BRv9hjlFbgv+jtRecZOHgnsLmso+ojVhkiypeGhLbdyQ==
   dependencies:
-    "@aztec/bb.js" "0.87.8"
-    "@aztec/constants" "0.87.8"
-    "@aztec/foundation" "0.87.8"
-    "@aztec/noir-noirc_abi" "0.87.8"
-    "@aztec/noir-protocol-circuits-types" "0.87.8"
-    "@aztec/noir-types" "0.87.8"
-    "@aztec/simulator" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
-    "@aztec/telemetry-client" "0.87.8"
-    "@aztec/world-state" "0.87.8"
+    "@aztec/bb.js" "0.87.9"
+    "@aztec/constants" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/noir-noirc_abi" "0.87.9"
+    "@aztec/noir-protocol-circuits-types" "0.87.9"
+    "@aztec/noir-types" "0.87.9"
+    "@aztec/simulator" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
+    "@aztec/telemetry-client" "0.87.9"
+    "@aztec/world-state" "0.87.9"
     commander "^12.1.0"
     pako "^2.1.0"
     source-map-support "^0.5.21"
@@ -132,6 +132,19 @@
     pino "^9.5.0"
     tslib "^2.4.0"
 
+"@aztec/bb.js@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-0.87.9.tgz#53f466c0ae8fa973d1a6c2ead824543c894ffa1f"
+  integrity sha512-opLGrEPszWL3YBiWgyGaBZrrN0ZOgPcnkh5G5uduLhvV7WUBGGxhosMhh3aw/Iiyn9gKnKPwpVYWr/+VlTCJ0g==
+  dependencies:
+    comlink "^4.4.1"
+    commander "^12.1.0"
+    idb-keyval "^6.2.1"
+    msgpackr "^1.11.2"
+    pako "^2.1.0"
+    pino "^9.5.0"
+    tslib "^2.4.0"
+
 "@aztec/blob-lib@0.86.0":
   version "0.86.0"
   resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-0.86.0.tgz#5efe2b57beb1b4ce7c826975ff8a2e6b963678ac"
@@ -152,13 +165,23 @@
     c-kzg "4.0.0-alpha.1"
     tslib "^2.4.0"
 
-"@aztec/builder@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-0.87.8.tgz#67dbf856815913a310cfc77d0b0538d659833ff8"
-  integrity sha512-cgi9zIWvYvMx2ZYw+jsQJrB0C9ALkbRaU2VNLqiIwHnBAb8ybwrmPvrDukyfBLeUTnf+hZYLf1myAGPoZOZCKg==
+"@aztec/blob-lib@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-0.87.9.tgz#359066ded01a576ddc9c789f55b51a0dd2f0378b"
+  integrity sha512-LDmNJDudj4oSMNwrxy7NHZQnr9LAvnXCpHfjQ13I1vNp4Hp4HBS+eyAS0bS+etnm5ohBXNLsKOEDZlLpKjIfjw==
   dependencies:
-    "@aztec/foundation" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
+    "@aztec/constants" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    c-kzg "4.0.0-alpha.1"
+    tslib "^2.4.0"
+
+"@aztec/builder@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-0.87.9.tgz#8af998db824b3963e438b1d6ba3edaed41e0ed83"
+  integrity sha512-JmOGzhKBou6YDtLIdmEcVrGgrMQoQJf7CLIjN5WCHHmWpfiA7NKwuavv8fgAxBcBGek0xrU7dwDgLAytuTYmXA==
+  dependencies:
+    "@aztec/foundation" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
     commander "^12.1.0"
 
 "@aztec/constants@0.86.0":
@@ -175,6 +198,13 @@
   dependencies:
     tslib "^2.4.0"
 
+"@aztec/constants@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-0.87.9.tgz#5ce9e30cb9f69b2108cbf8dea6617444f4e255e0"
+  integrity sha512-3vIndqlRlDu7Z22AcGmROPtxdr0SKU/HL8Jd/AA5ngsAeng6Mbh378giB2I3aa7OV/+q5bnGH6erPjWWQYa+/A==
+  dependencies:
+    tslib "^2.4.0"
+
 "@aztec/entrypoints@0.86.0":
   version "0.86.0"
   resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-0.86.0.tgz#1a81868563bff11bc6d5060db44fed8bd6edcf42"
@@ -186,15 +216,15 @@
     "@aztec/stdlib" "0.86.0"
     tslib "^2.4.0"
 
-"@aztec/entrypoints@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-0.87.8.tgz#08e19e68228a0b7263bad46dda85da3961154878"
-  integrity sha512-OucqC96Cw+PY0aOf1piofsX0cwIJ9lONfpCQmH7OEgjTN1kaube6WluuHJ1RU71XQsZmyQmjtZB3vaoerhWO/Q==
+"@aztec/entrypoints@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-0.87.9.tgz#5662c6c468f99c81aa89341c6191e6a339d4b0d2"
+  integrity sha512-zIhgZLPNrzbuXaXhN5NUAzUmZT4wMutD2lc8iHIdXpKgySC9m2hW8W2UBSlmNKlmuzFbAoVDO7VnfFWtZU2z0w==
   dependencies:
-    "@aztec/constants" "0.87.8"
-    "@aztec/foundation" "0.87.8"
-    "@aztec/protocol-contracts" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
+    "@aztec/constants" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/protocol-contracts" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
     tslib "^2.4.0"
 
 "@aztec/ethereum@0.86.0":
@@ -219,6 +249,20 @@
     "@aztec/blob-lib" "0.87.8"
     "@aztec/foundation" "0.87.8"
     "@aztec/l1-artifacts" "0.87.8"
+    "@viem/anvil" "^0.0.10"
+    dotenv "^16.0.3"
+    tslib "^2.4.0"
+    viem "2.23.7"
+    zod "^3.23.8"
+
+"@aztec/ethereum@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-0.87.9.tgz#8697a455e4a63642358abe3b80f8e6c3e9ee6efd"
+  integrity sha512-k8q1eH9OlimkSmmQYoE7jsFpofbWRDMnWsup9jho6ao9y7E7F74B9wJ9BEteBU3gOcKRELXdZYnJTgKuc2SnRg==
+  dependencies:
+    "@aztec/blob-lib" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/l1-artifacts" "0.87.9"
     "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
     tslib "^2.4.0"
@@ -279,26 +323,52 @@
     undici "^5.28.5"
     zod "^3.23.8"
 
-"@aztec/key-store@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-0.87.8.tgz#973f4936a1f0ed05118e23b42004e37ba78eb9be"
-  integrity sha512-yYLCMqXf23wwf6bWaBt/67MnUTfh0rNQ4zWfnwl8AudVQRwSAltKlD6dFGaQeeIB+JF31QcaVoltBogVq1pnoA==
+"@aztec/foundation@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-0.87.9.tgz#beeed3b86d67652f377bdfa01482444663bd45db"
+  integrity sha512-fM2BgMpOg04gZDScM85x6NFqwpH+zFew8vtBsI3ajR0TwZW7n1DWERl3JvCfs33DGioFUTKBOzY5CaaIm7GZ6g==
   dependencies:
-    "@aztec/constants" "0.87.8"
-    "@aztec/foundation" "0.87.8"
-    "@aztec/kv-store" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
+    "@aztec/bb.js" "0.87.9"
+    "@koa/cors" "^5.0.0"
+    "@noble/curves" "^1.2.0"
+    c-kzg "4.0.0-alpha.1"
+    colorette "^2.0.20"
+    detect-node "^2.1.0"
+    hash.js "^1.1.7"
+    koa "^2.16.1"
+    koa-bodyparser "^4.4.0"
+    koa-compress "^5.1.0"
+    koa-router "^12.0.0"
+    leveldown "^6.1.1"
+    lodash.chunk "^4.2.0"
+    lodash.clonedeepwith "^4.5.0"
+    pako "^2.1.0"
+    pino "^9.5.0"
+    pino-pretty "^13.0.0"
+    sha3 "^2.1.4"
+    undici "^5.28.5"
+    zod "^3.23.8"
+
+"@aztec/key-store@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-0.87.9.tgz#d85e34eefdcb5bda47805dabb16e96ebc7be8c58"
+  integrity sha512-RAbhBQhcxHRv4qYzvoaAzXNYj01IW3r29eCJP6stK6oPYOTgoBZUf7F7n21hyym0y/q/b2i4mUY00qZpmaKIRg==
+  dependencies:
+    "@aztec/constants" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/kv-store" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
     tslib "^2.4.0"
 
-"@aztec/kv-store@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-0.87.8.tgz#887ab05386ed4b7ec5d593b946ed723be6cb9be9"
-  integrity sha512-VOYezDajNM3PCnvweLC/YaT0/PGctwVWLXrHXIc5YSDUVRmwXeyEB+pOt1LdKD+7XExA0EPdwbdf6zAdZ+qi9g==
+"@aztec/kv-store@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-0.87.9.tgz#44bed0061de40f02c4ad8c61d00463ba660054aa"
+  integrity sha512-/NBf3rEW2cCpMkBBDVDf4FNBKtryLT8ldW1mASXB6ES3aplkgRAKjOTsyDErXx4nCvzZr1HQWb9Rbygk2T6Ipg==
   dependencies:
-    "@aztec/ethereum" "0.87.8"
-    "@aztec/foundation" "0.87.8"
-    "@aztec/native" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
+    "@aztec/ethereum" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/native" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
     idb "^8.0.0"
     lmdb "^3.2.0"
     msgpackr "^1.11.2"
@@ -319,45 +389,52 @@
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/merkle-tree@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-0.87.8.tgz#c5b4b112b2cbdff5d51dae6daaede3e7323073f9"
-  integrity sha512-AV1/57VTzTvMHGukHq+c80ZVmqHkMmYR7LTj9GADPK4lvvHbxofkoGa9Pz8OEY6WV8uHGsd7Oewb2Pm5TRv/8Q==
+"@aztec/l1-artifacts@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-0.87.9.tgz#a4aefb27563123221132c6bd8adf64dcce80baa0"
+  integrity sha512-vqmHhDNMSQMw9nM+AmVr+5eOHIONkhfRl5uyMAx7FdosqNspFmeBZtYsp41ZgMlSSx/+NknEp61pKY/H+f7apA==
   dependencies:
-    "@aztec/foundation" "0.87.8"
-    "@aztec/kv-store" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
+    tslib "^2.4.0"
+
+"@aztec/merkle-tree@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-0.87.9.tgz#fcb9ce539c62cf2c926baa04ba0870711a9883d4"
+  integrity sha512-EbLAzXisGvQpJ9clKTfyDu7agYNUakxUUJJHQbCPgXQNn1vAfvZScbPuGuy6FRN+pmRwHEy+IRygLga7dibhRA==
+  dependencies:
+    "@aztec/foundation" "0.87.9"
+    "@aztec/kv-store" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
     sha256 "^0.2.0"
     tslib "^2.4.0"
 
-"@aztec/native@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-0.87.8.tgz#5a99f78f87473745e2f6b5e9f8cf742d23d53d7c"
-  integrity sha512-vdQ0M7Caj5vsR63XTnbol6V29cqR9qF76GuOBfYrPtHuBHTctVdT30bVTi7CnRnZvadXIUa5zhzrW1yFebYF0w==
+"@aztec/native@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-0.87.9.tgz#dda8fa23d0071d535735988156d7e22439816b78"
+  integrity sha512-TI3lO/7S4UwphfF5lyj2A/W+ZtcXBlsNai8b4cN9tDVfP3MZGRxGZVNdiiZ0wiOXP2EtzQ+uIhBOBqcPQUMqCw==
   dependencies:
-    "@aztec/foundation" "0.87.8"
+    "@aztec/foundation" "0.87.9"
     bindings "^1.5.0"
     msgpackr "^1.11.2"
 
-"@aztec/noir-acvm_js@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-0.87.8.tgz#2244e8f8e684990bf19b49ebb98f89800483034d"
-  integrity sha512-Slw7oSHjxmOho4Ebjr+cWM6MR2Bp+gm8h6VMkZKDFlp+EpIvhExm7DgVWbPKcjwJQysXdkK4hUkEtGYibb1d+g==
+"@aztec/noir-acvm_js@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-0.87.9.tgz#4bb064f8a7cdfeb7ef94bcacf98370eb0c0e83d7"
+  integrity sha512-aoWgNMMEHKU4fpn6+OGigUyaOqp8UyfNMlB2hz0g1AeOZ6hVq036v7nQv1McVxXOxcVzdD7Dpf1nG/eUABCpKg==
 
-"@aztec/noir-contracts.js@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-0.87.8.tgz#b20d7c41a3bebd11df6fff62756ca7d1a65589b3"
-  integrity sha512-nrH9K7jCdlBBuYYUsGSfj3ca+pmqyHr4KG5YbnNn3Dm46s9WmTcwCqKM5aha7yaNbGiBtGW4E30bjDkrZxUvZg==
+"@aztec/noir-contracts.js@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-0.87.9.tgz#e8727b4b5c1e37b67efda5ff838099273d8148f3"
+  integrity sha512-OgsmlUOqeIBEgiWx2GivSihs/z56ft5nRiMYL+NNv/9LWG3B4H9JQ50eQV0xs2C1pILpfbTbEffLJ+A4ZOotaA==
   dependencies:
-    "@aztec/aztec.js" "0.87.8"
+    "@aztec/aztec.js" "0.87.9"
     tslib "^2.4.0"
 
-"@aztec/noir-noir_codegen@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-0.87.8.tgz#b742a1f7c0d2760379dc321440e34a2d64a225fd"
-  integrity sha512-cV+OXNPD4FE8uGNkqVatdB44od7zX4FZLAkwSGCJfNEOKsgjlznR5ROQ44C2USUD4JEnczptlBnZbp25Ql4P0g==
+"@aztec/noir-noir_codegen@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-0.87.9.tgz#0f5e14cd1e36452178176723afe1c11be3660cc8"
+  integrity sha512-dFa/k07dXIH1d3tmANVxvOKnu9Qdu0lLVrZLRogmN68wuFO/W3zdT3J/rQjUBtCdDhbi0AaZtXLKyF/ePPeOTg==
   dependencies:
-    "@aztec/noir-types" "0.87.8"
+    "@aztec/noir-types" "0.87.9"
     glob "^11.0.1"
     ts-command-line-args "^2.5.1"
 
@@ -375,19 +452,26 @@
   dependencies:
     "@aztec/noir-types" "0.87.8"
 
-"@aztec/noir-protocol-circuits-types@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-0.87.8.tgz#4f2e02e659350597c6dd9fc44b207458ff059512"
-  integrity sha512-9gUPokedG9O8xzZ4jBZlcKldZyRM7b3EbB/zF/qhrDF0qLZ+Mt2Ld/3d9tV8oaVsSw5HZKW0b2wynI8pDx+ASA==
+"@aztec/noir-noirc_abi@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-0.87.9.tgz#3f1c6b71bd83410b8600be0c350b35ae52d25755"
+  integrity sha512-sPfRxkf7cEOOZevj62IZt6GO2VA/gDDxp/sX1/Wy1S0m9sNhV0C0RQGXqMv4SiEsNPyMxAbIkbiCY1IrIqZ9Sg==
   dependencies:
-    "@aztec/blob-lib" "0.87.8"
-    "@aztec/constants" "0.87.8"
-    "@aztec/foundation" "0.87.8"
-    "@aztec/noir-acvm_js" "0.87.8"
-    "@aztec/noir-noir_codegen" "0.87.8"
-    "@aztec/noir-noirc_abi" "0.87.8"
-    "@aztec/noir-types" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
+    "@aztec/noir-types" "0.87.9"
+
+"@aztec/noir-protocol-circuits-types@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-0.87.9.tgz#dcc1c176fe3a2d610332c89a4eac2c3f0365154c"
+  integrity sha512-cyIN80o7ZOaw+yEoVJcGESGXqQL1UeTS0hjrXieMIgFmOhRTE+vrGNCZsLQvSgztwyU3whGqTyS8vO44QYRH1g==
+  dependencies:
+    "@aztec/blob-lib" "0.87.9"
+    "@aztec/constants" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/noir-acvm_js" "0.87.9"
+    "@aztec/noir-noir_codegen" "0.87.9"
+    "@aztec/noir-noirc_abi" "0.87.9"
+    "@aztec/noir-types" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
     change-case "^5.4.4"
     tslib "^2.4.0"
 
@@ -401,6 +485,11 @@
   resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-0.87.8.tgz#3a82ba180cb7a49aff53189bf4717fea5031cbc6"
   integrity sha512-LZS6gaI6dEAcRgpZd7hc+uREjfOOUwQbBkoNQf4L96Tb11sF+IvZ32h8eR4GYM/vrofW24ZUS4AvS3JSB4PZrQ==
 
+"@aztec/noir-types@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-0.87.9.tgz#525807a679a9e4bda2735eb99cc57ce47100e413"
+  integrity sha512-UhRuJ4H2nFZiQk9KbWn4Yk56IwdZ06T2QRzCD9LurpTEABTMrPFlQS0PK8OS4dqcs/s3OhA1GPJ70emQ0bUk7Q==
+
 "@aztec/protocol-contracts@0.86.0":
   version "0.86.0"
   resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-0.86.0.tgz#10b965cf9ae6db17357dca8ecaae27b95495a976"
@@ -413,36 +502,36 @@
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/protocol-contracts@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-0.87.8.tgz#1d119ad0992b65398f5bfc127d264cad4ac329dc"
-  integrity sha512-Y0wHf8m3Jj5Fj6Xk02Vn1UH2SHzRgjQcscr4R3jKyT0eR+5Qyf5gDXwAMImhA8gEuSvPczwZ2y8Uk3JcylMfRg==
+"@aztec/protocol-contracts@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-0.87.9.tgz#f0bbbbeb7a0769424e110a78426473daaa42284d"
+  integrity sha512-uSfheAbddQNr4Co3BV+IZLPcOMb0nZs54prJN9fazSGKfW8Bpz6CnN+GgBpIJ0gf6IbN7xUKWR0LV8NwNLjGvg==
   dependencies:
-    "@aztec/constants" "0.87.8"
-    "@aztec/foundation" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
+    "@aztec/constants" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
     lodash.chunk "^4.2.0"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/pxe@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-0.87.8.tgz#bbac7341cdb27e3bed23c2484fafbcb9e97938f5"
-  integrity sha512-1egvKI+TP2gFwNr31JaOIdNKwDxBnB6tAmfsSQ+VsqDWAg0QZjFTl2t69p8aRtHFKDW/RUFAeHZZB5rCU96ACA==
+"@aztec/pxe@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-0.87.9.tgz#9cb0089efb24be75f484fb1f8635fb2680a48998"
+  integrity sha512-ZmzUz0/ZCCJHOPQEm9YOgOrMpt6+2ZmhSFT5rGYfTMOuPO0TwpyBZY90yQr+cTc1WWg+Pidp69vz3LNc4ZeDrw==
   dependencies:
-    "@aztec/bb-prover" "0.87.8"
-    "@aztec/bb.js" "0.87.8"
-    "@aztec/builder" "0.87.8"
-    "@aztec/constants" "0.87.8"
-    "@aztec/ethereum" "0.87.8"
-    "@aztec/foundation" "0.87.8"
-    "@aztec/key-store" "0.87.8"
-    "@aztec/kv-store" "0.87.8"
-    "@aztec/noir-protocol-circuits-types" "0.87.8"
-    "@aztec/noir-types" "0.87.8"
-    "@aztec/protocol-contracts" "0.87.8"
-    "@aztec/simulator" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
+    "@aztec/bb-prover" "0.87.9"
+    "@aztec/bb.js" "0.87.9"
+    "@aztec/builder" "0.87.9"
+    "@aztec/constants" "0.87.9"
+    "@aztec/ethereum" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/key-store" "0.87.9"
+    "@aztec/kv-store" "0.87.9"
+    "@aztec/noir-protocol-circuits-types" "0.87.9"
+    "@aztec/noir-types" "0.87.9"
+    "@aztec/protocol-contracts" "0.87.9"
+    "@aztec/simulator" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
     koa "^2.16.1"
     koa-router "^12.0.0"
     lodash.omit "^4.5.0"
@@ -450,21 +539,21 @@
     tslib "^2.4.0"
     viem "2.23.7"
 
-"@aztec/simulator@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-0.87.8.tgz#971b9580d918d7e90a1a6332278bdff5b9b8c004"
-  integrity sha512-xE7BuYD4Z0POgKGv9YAdgzaE+ZBy5r3ChKDlmuFuG7WPvQmTTclmNbs5x+usmuq37jmPq7auM3C7RggftjOByg==
+"@aztec/simulator@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-0.87.9.tgz#11d998a19b2237e86c9afefecc5bfc9945dd11e4"
+  integrity sha512-Zw/N0zi3OvvtgNCj48n1Sp/W3ofMEeLBsiff+qvXJnER/QJ02+T7MjZedWVgDvuB6e38NSuQMeu+VEaYaLA2yQ==
   dependencies:
-    "@aztec/constants" "0.87.8"
-    "@aztec/foundation" "0.87.8"
-    "@aztec/noir-acvm_js" "0.87.8"
-    "@aztec/noir-noirc_abi" "0.87.8"
-    "@aztec/noir-protocol-circuits-types" "0.87.8"
-    "@aztec/noir-types" "0.87.8"
-    "@aztec/protocol-contracts" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
-    "@aztec/telemetry-client" "0.87.8"
-    "@aztec/world-state" "0.87.8"
+    "@aztec/constants" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/noir-acvm_js" "0.87.9"
+    "@aztec/noir-noirc_abi" "0.87.9"
+    "@aztec/noir-protocol-circuits-types" "0.87.9"
+    "@aztec/noir-types" "0.87.9"
+    "@aztec/protocol-contracts" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
+    "@aztec/telemetry-client" "0.87.9"
+    "@aztec/world-state" "0.87.9"
     lodash.clonedeep "^4.5.0"
     lodash.merge "^4.6.2"
     tslib "^2.4.0"
@@ -515,13 +604,37 @@
     viem "2.23.7"
     zod "^3.23.8"
 
-"@aztec/telemetry-client@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-0.87.8.tgz#fcd30ce97081f84a0a8540f68dae76ca377e5921"
-  integrity sha512-YzHhT6GbrteueqbeCnNMTLmrSkQtp4DLss60RATEJ8VehylfoH5m2BCGA/LQ7eHQqz9+979QeM6ZzVDXqfHUTQ==
+"@aztec/stdlib@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-0.87.9.tgz#ad68152abd257f3f93610ac3ea97d78633a88589"
+  integrity sha512-Vzjo7Bb6egSVCOY1wnAW8mGBzbC4WEPblY+9c/aIxjX04yWyR46NE1hnkS0eptSxORWkLfgbJfP/FixMHfaVgg==
   dependencies:
-    "@aztec/foundation" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
+    "@aztec/bb.js" "0.87.9"
+    "@aztec/blob-lib" "0.87.9"
+    "@aztec/constants" "0.87.9"
+    "@aztec/ethereum" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/noir-noirc_abi" "0.87.9"
+    "@google-cloud/storage" "^7.15.0"
+    axios "^1.9.0"
+    json-stringify-deterministic "1.0.12"
+    lodash.chunk "^4.2.0"
+    lodash.isequal "^4.5.0"
+    lodash.omit "^4.5.0"
+    lodash.times "^4.3.2"
+    msgpackr "^1.11.2"
+    pako "^2.1.0"
+    tslib "^2.4.0"
+    viem "2.23.7"
+    zod "^3.23.8"
+
+"@aztec/telemetry-client@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-0.87.9.tgz#81c5353c0221b26d58d297dbc8f77573a80e8429"
+  integrity sha512-aJ+sGjR6LGN3+2n5taraiKEwJw6KUV20FBph/nThu7CqMnMhZ2kNHk0ge5mE+Blozzkf8imxPK33N5JkmsunLg==
+  dependencies:
+    "@aztec/foundation" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/api-logs" "^0.55.0"
     "@opentelemetry/core" "^1.28.0"
@@ -539,19 +652,19 @@
     prom-client "^15.1.3"
     viem "2.23.7"
 
-"@aztec/world-state@0.87.8":
-  version "0.87.8"
-  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-0.87.8.tgz#d8e9decf39928b3c029bd0d6634b90a23fc7842e"
-  integrity sha512-McxaWk5++aSsCciHr9wVefaMcCd4WM6Q+er5JtJYUIpLVAbaspfLOPsApoSQh9pskn+paqEE233xU3ZpaNisDw==
+"@aztec/world-state@0.87.9":
+  version "0.87.9"
+  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-0.87.9.tgz#d5969b350793d8d946fe6858e2fae94beb1181d4"
+  integrity sha512-ZJUnuM/YpwtLzQvQo2MJk5qTKoTCrQo7b7veam2nl8DkJIGDP/EADyKEcQDllugVp/uBR3fdmiJYhtTotJYwmw==
   dependencies:
-    "@aztec/constants" "0.87.8"
-    "@aztec/foundation" "0.87.8"
-    "@aztec/kv-store" "0.87.8"
-    "@aztec/merkle-tree" "0.87.8"
-    "@aztec/native" "0.87.8"
-    "@aztec/protocol-contracts" "0.87.8"
-    "@aztec/stdlib" "0.87.8"
-    "@aztec/telemetry-client" "0.87.8"
+    "@aztec/constants" "0.87.9"
+    "@aztec/foundation" "0.87.9"
+    "@aztec/kv-store" "0.87.9"
+    "@aztec/merkle-tree" "0.87.9"
+    "@aztec/native" "0.87.9"
+    "@aztec/protocol-contracts" "0.87.9"
+    "@aztec/stdlib" "0.87.9"
+    "@aztec/telemetry-client" "0.87.9"
     tslib "^2.4.0"
     zod "^3.23.8"
 


### PR DESCRIPTION
# 🤖 Linear

Closes AZT-249

## Description 

This PR was tested using 0.87.9 because the public testnet is still at that version.

To run this deploy script you need to have a PXE running. You can use the sandbox for local testing, or you can have a PXE connected to a testnet aztec node for public deployment using something like this:

```
AZTEC_NODE_URL='https://full-node.alpha-testnet.aztec.network/' \
aztec start --pxe --port 8081 \
--l1-rpc-urls 'https://sepolia.drpc.org' --l1-chain-id 11155111
```

Any sepolia RPC should work, but the L1 RPC URL, in this example above I'm using a public node.