### PR TITLE
chore: release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - main
     inputs:
       version:
-        description: 'Version to release (e.g., 1.0.0, 1.0.0-beta.1)'
+        description: 'Version to release (e.g., 1.0.0, 1.0.0-beta.1). Do NOT include the "v" prefix; the workflow adds it when tagging.'
         required: true
         type: string
 
@@ -129,10 +129,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Create GitHub Release Tag
+      - name: Create GitHub Release Tag (adds 'v' prefix to input)
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          echo "Tagging release as v${{ github.event.inputs.version }}"
           git tag -a v${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
           git push origin v${{ github.event.inputs.version }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
+          node-version: '20'
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
 
@@ -62,10 +63,7 @@ jobs:
 
       - name: Set Aztec version
         run: |
-          VERSION=${AZTEC_VERSION} aztec-up
-
-      
-      # Install dependencies AND the current latest version of the package we're releasing now.
+          VERSION=${{ steps.aztec-version.outputs.AZTEC_VERSION }} aztec-up
       - name: Install dependencies
         run: |
           yarn --frozen-lockfile
@@ -141,10 +139,13 @@ jobs:
 
       - name: Create GitHub Release Tag (adds 'v' prefix to input)
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          echo "Tagging release as v${{ github.event.inputs.version }}"
-          git tag -a v${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
-          git push origin v${{ github.event.inputs.version }}
+          TAG_NAME="v${{ github.event.inputs.version }}"
+          # Check if tag already exists
+          if git ls-remote --tags origin | grep -q "refs/tags/${TAG_NAME}$"; then
+            echo "::error::Tag ${TAG_NAME} already exists. Please use a different version."
+            exit 1
+          fi
+          git tag "${TAG_NAME}"
+          git push origin "${TAG_NAME}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,22 @@
 name: Production Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    branches:
+      - main
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.0.0, 1.0.0-beta.1)'
+        required: true
+        type: string
 
 jobs:
   release:
     name: Release
     environment: Production
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to create and push tags
 
     env:
       PROJECT_NAME: '@defi-wonderland/aztec-standards'
@@ -43,6 +51,10 @@ jobs:
       - name: Set Aztec version
         run: |
           VERSION=${AZTEC_VERSION} aztec-up
+
+      - name: Update package version
+        run: |
+          npm version ${{ github.event.inputs.version }} --no-git-tag-version --allow-same-version
       
       # Install dependencies AND the current latest version of the package we're releasing now.
       - name: Install dependencies
@@ -71,7 +83,7 @@ jobs:
       # 7. Trim info from package.json
       - name: Prepare files for release
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION=${{ github.event.inputs.version }}
           mkdir -p export/${{ env.PROJECT_NAME }}/current/artifacts
           mkdir -p export/${{ env.PROJECT_NAME }}/historical
           
@@ -116,3 +128,12 @@ jobs:
         run: cd export/${{ env.PROJECT_NAME }} && npm publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release Tag
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a v${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
+          git push origin v${{ github.event.inputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,9 @@ name: Production Release
 
 on:
   workflow_dispatch:
-    branches:
-      - main
     inputs:
       version:
-        description: 'Version to release (e.g., 1.0.0, 1.0.0-beta.1). Do NOT include the "v" prefix; the workflow adds it when tagging.'
+        description: 'Version from package.json (e.g., 1.0.0 or 1.0.0-beta.1). Do NOT include the "v" prefix.'
         required: true
         type: string
 
@@ -15,6 +13,7 @@ jobs:
     name: Release
     environment: Production
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write  # Required to create and push tags
 
@@ -30,6 +29,19 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
+
+      # TODO: Automate changing package.json version from the workflow input
+      #       (e.g., open a PR or push a signed commit) so manual edits are not required.
+      - name: Validate input version matches package.json
+        run: |
+          INPUT_VERSION="${{ github.event.inputs.version }}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "Input version: $INPUT_VERSION"
+          echo "package.json version: $PKG_VERSION"
+          if [ "$INPUT_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Input version ($INPUT_VERSION) does not match package.json version ($PKG_VERSION). Update package.json or re-run with the matching version (no 'v' prefix)."
+            exit 1
+          fi
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v2
@@ -52,9 +64,6 @@ jobs:
         run: |
           VERSION=${AZTEC_VERSION} aztec-up
 
-      - name: Update package version
-        run: |
-          npm version ${{ github.event.inputs.version }} --no-git-tag-version --allow-same-version
       
       # Install dependencies AND the current latest version of the package we're releasing now.
       - name: Install dependencies
@@ -122,7 +131,8 @@ jobs:
           cp -r export/${{ env.PROJECT_NAME }}/current export/${{ env.PROJECT_NAME }}/historical/$VERSION
           cp README.md export/${{ env.PROJECT_NAME }}/
           cp LICENSE export/${{ env.PROJECT_NAME }}/
-          cat package.json | jq 'del(.scripts, .jest, ."lint-staged", .packageManager, .devDependencies, .dependencies, .engines, .resolutions)' > export/${{ env.PROJECT_NAME }}/package.json
+          # Trim fields and set the version to the workflow input so the published package matches the requested version
+          cat package.json | jq --arg v "$VERSION" 'del(.scripts, .jest, ."lint-staged", .packageManager, .devDependencies, .dependencies, .engines, .resolutions) | .version=$v' > export/${{ env.PROJECT_NAME }}/package.json
 
       - name: Publish to NPM
         run: cd export/${{ env.PROJECT_NAME }} && npm publish --access public --tag latest


### PR DESCRIPTION
# 🤖 Linear

Closes AZT-287

## Description 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now requires manual trigger with a specified version and validates that input matches package version.
  * Workflow restricted to the main branch and granted necessary write permissions for tagging.
  * Standardized use of the workflow version input throughout the release steps.
  * Updated Node runtime and added automated creation of a v-prefixed release tag after publish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->