### PR TITLE
fix: remove unused validity commitment

### DIFF
--- a/src/token_contract/src/main.nr
+++ b/src/token_contract/src/main.nr
@@ -655,7 +655,6 @@ pub contract Token {
         completer: AztecAddress,
         amount: u128,
     ) {
-        let validity_commitment = commitment.compute_validity_commitment(completer);
         commitment.complete(context, completer, amount);
     }
 


### PR DESCRIPTION
# 🤖 Linear

Closes #177 

## Description 

We have [this](https://github.com/defi-wonderland/aztec-standards/blob/4d6b88f1d4ed46c7c2660d9a183eeba1edabf3d9/src/token_contract/src/main.nr#L658) unused validity commitment, that is unused and should be removed.

The complete function, which is called later, takes care of checking the validity of the commitment and its inclusion in the nullifier tree later on, so we can remove it.