### PR TITLE
ci: add write permissions for issues

### DIFF
--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -10,6 +10,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 env:
   BENCH_DIR: ./benchmarks


### PR DESCRIPTION
# 🤖 Linear

Closes AZT-XXX

## Description 

Allows the workflow to write in issues (and hopefully PRs as well), so workflow runs initiated by PRs from external can comment on it.