### PR TITLE
ci: update to test benchmark with circuit details

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,6 +15,7 @@ jobs:
   benchmark:
     uses: defi-wonderland/aztec-benchmark/.github/workflows/pr-benchmark.yml@feat/circuit-gate-details
     permissions:
+      contents: read
       pull-requests: write
       issues: write
       actions: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ jobs:
     secrets: inherit
 
   benchmark:
-    uses: defi-wonderland/aztec-benchmark/.github/workflows/pr-benchmark.yml@4.0.0-devnet.1-patch.0
+    uses: defi-wonderland/aztec-benchmark/.github/workflows/pr-benchmark.yml@feat/circuit-gate-details
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,6 +14,8 @@ jobs:
 
   benchmark:
     uses: defi-wonderland/aztec-benchmark/.github/workflows/pr-benchmark.yml@feat/circuit-gate-details
+    with:
+      circuit-details: true
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   baseline:
-    uses: defi-wonderland/aztec-benchmark/.github/workflows/update-baseline.yml@4.0.0-devnet.1-patch.0
+    uses: defi-wonderland/aztec-benchmark/.github/workflows/update-baseline.yml@feat/circuit-gate-details
     permissions:
       contents: read
       actions: write

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@aztec/pxe": "4.0.0-devnet.2-patch.1",
     "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
     "@aztec/wallets": "4.0.0-devnet.2-patch.1",
-    "@defi-wonderland/aztec-benchmark": "defi-wonderland/aztec-benchmark#feat/circuit-gate-details"
+    "@defi-wonderland/aztec-benchmark": "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-aa67384/defi-wonderland-aztec-benchmark-4.0.0-devnet.2-patch.1-prerelease.aa67384.tgz"
   },
   "devDependencies": {
     "@commitlint/cli": "20.3.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@aztec/pxe": "4.0.0-devnet.2-patch.1",
     "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
     "@aztec/wallets": "4.0.0-devnet.2-patch.1",
-    "@defi-wonderland/aztec-benchmark": "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-aa67384/defi-wonderland-aztec-benchmark-4.0.0-devnet.2-patch.1-prerelease.aa67384.tgz"
+    "@defi-wonderland/aztec-benchmark": "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-da98a15/defi-wonderland-aztec-benchmark-4.0.0-devnet.2-patch.1-prerelease.da98a15.tgz"
   },
   "devDependencies": {
     "@commitlint/cli": "20.3.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@aztec/pxe": "4.0.0-devnet.2-patch.1",
     "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
     "@aztec/wallets": "4.0.0-devnet.2-patch.1",
-    "@defi-wonderland/aztec-benchmark": "4.0.0-devnet.2-patch.1"
+    "@defi-wonderland/aztec-benchmark": "defi-wonderland/aztec-benchmark#feat/circuit-gate-details"
   },
   "devDependencies": {
     "@commitlint/cli": "20.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,9 +1258,9 @@
     "@crate-crypto/node-eth-kzg-win32-arm64-msvc" "0.10.0"
     "@crate-crypto/node-eth-kzg-win32-x64-msvc" "0.10.0"
 
-"@defi-wonderland/aztec-benchmark@defi-wonderland/aztec-benchmark#feat/circuit-gate-details":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://codeload.github.com/defi-wonderland/aztec-benchmark/tar.gz/aa67384e7ebd8ee2f6fd6c9c79d6da14ffb2e1c0"
+"@defi-wonderland/aztec-benchmark@https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-aa67384/defi-wonderland-aztec-benchmark-4.0.0-devnet.2-patch.1-prerelease.aa67384.tgz":
+  version "4.0.0-devnet.2-patch.1-prerelease.aa67384"
+  resolved "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-aa67384/defi-wonderland-aztec-benchmark-4.0.0-devnet.2-patch.1-prerelease.aa67384.tgz#53ad723e6c126cc6f789b9a9258484124956c42b"
   dependencies:
     "@actions/core" "1.10.1"
     "@actions/exec" "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,10 +1258,9 @@
     "@crate-crypto/node-eth-kzg-win32-arm64-msvc" "0.10.0"
     "@crate-crypto/node-eth-kzg-win32-x64-msvc" "0.10.0"
 
-"@defi-wonderland/aztec-benchmark@4.0.0-devnet.2-patch.1":
+"@defi-wonderland/aztec-benchmark@defi-wonderland/aztec-benchmark#feat/circuit-gate-details":
   version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@defi-wonderland/aztec-benchmark/-/aztec-benchmark-4.0.0-devnet.2-patch.1.tgz#a291dad485bdc38ca30a087db5e7405eb729388d"
-  integrity sha512-++6E0FLaUUVYHGIYw+uvgx2xYVU0fkgFzwW0w3EJintvw8KsiU30pe6kk2/QGbtfbe08BdiCNNawfDrOU3oFiw==
+  resolved "https://codeload.github.com/defi-wonderland/aztec-benchmark/tar.gz/aa67384e7ebd8ee2f6fd6c9c79d6da14ffb2e1c0"
   dependencies:
     "@actions/core" "1.10.1"
     "@actions/exec" "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,9 +1258,9 @@
     "@crate-crypto/node-eth-kzg-win32-arm64-msvc" "0.10.0"
     "@crate-crypto/node-eth-kzg-win32-x64-msvc" "0.10.0"
 
-"@defi-wonderland/aztec-benchmark@https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-aa67384/defi-wonderland-aztec-benchmark-4.0.0-devnet.2-patch.1-prerelease.aa67384.tgz":
-  version "4.0.0-devnet.2-patch.1-prerelease.aa67384"
-  resolved "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-aa67384/defi-wonderland-aztec-benchmark-4.0.0-devnet.2-patch.1-prerelease.aa67384.tgz#53ad723e6c126cc6f789b9a9258484124956c42b"
+"@defi-wonderland/aztec-benchmark@https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-da98a15/defi-wonderland-aztec-benchmark-4.0.0-devnet.2-patch.1-prerelease.da98a15.tgz":
+  version "4.0.0-devnet.2-patch.1-prerelease.da98a15"
+  resolved "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-da98a15/defi-wonderland-aztec-benchmark-4.0.0-devnet.2-patch.1-prerelease.da98a15.tgz#51ad392742e0ebec544621c3106058eaff1c6fac"
   dependencies:
     "@actions/core" "1.10.1"
     "@actions/exec" "1.1.1"


### PR DESCRIPTION
# 🤖 Linear

Closes AZT-XXX

## Description 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI to aztec-benchmark circuit gate details workflows so PR checks and baseline updates include gate-level metrics, and add contents: read to the benchmark job. Use the aztec-benchmark prerelease to test circuit details as required.

- **Dependencies**
  - pr-checks.yml and update-baseline.yml now use aztec-benchmark workflows at feat/circuit-gate-details; benchmark job has contents: read.
  - @defi-wonderland/aztec-benchmark now points to a GitHub prerelease tarball; yarn.lock updated.

<sup>Written for commit c60b19c6013c4e0012723a5b5de91e89e3d5cfd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

