### PR TITLE
feat: add authorize_once macro

### DIFF
--- a/src/nft_contract/src/main.nr
+++ b/src/nft_contract/src/main.nr
@@ -7,13 +7,9 @@ use aztec::macros::aztec;
 pub contract NFT {
     // aztec library
     use aztec::{
-        authwit::auth::{
-            assert_current_call_valid_authwit, assert_current_call_valid_authwit_public,
-        },
-        context::PrivateContext,
         macros::{
             events::event,
-            functions::{external, initializer, internal, only_self, view},
+            functions::{authorize_once, external, initializer, internal, only_self, view},
             storage::storage,
         },
         messages::message_delivery::MessageDelivery,
@@ -80,6 +76,7 @@ pub contract NFT {
     /// @param to The address of the recipient
     /// @param token_id The id of the token to transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn transfer_private_to_public(
         from: AztecAddress,
@@ -87,8 +84,6 @@ pub contract NFT {
         token_id: Field,
         _nonce: Field,
     ) {
-        _validate_from_private::<4>(self.context, from);
-
         self.internal._remove_private_token_owner(from, token_id);
         self.enqueue_self.update_public_token_owner_from_zero_internal(to, token_id);
     }
@@ -100,6 +95,7 @@ pub contract NFT {
     /// @param token_id The id of the token to transfer
     /// @param _nonce The nonce used for authwitness
     /// @return commitment The partial nft note utilized for the transfer commitment (privacy entrance)
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn transfer_private_to_public_with_commitment(
         from: AztecAddress,
@@ -107,8 +103,6 @@ pub contract NFT {
         token_id: Field,
         _nonce: Field,
     ) -> Field {
-        _validate_from_private::<4>(self.context, from);
-
         self.internal._remove_private_token_owner(from, token_id);
         self.enqueue_self.update_public_token_owner_from_zero_internal(to, token_id);
         let completer = self.msg_sender();
@@ -122,6 +116,7 @@ pub contract NFT {
     /// @param to The address of the recipient
     /// @param token_id The id of the token to transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn transfer_private_to_private(
         from: AztecAddress,
@@ -129,8 +124,6 @@ pub contract NFT {
         token_id: Field,
         _nonce: Field,
     ) {
-        _validate_from_private::<4>(self.context, from);
-
         self.internal._remove_private_token_owner(from, token_id);
         self.internal._update_private_token_owner(to, token_id);
     }
@@ -141,6 +134,7 @@ pub contract NFT {
     /// @param token_id The id of the token to transfer
     /// @param commitment The commitment to use for the transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn transfer_private_to_commitment(
         from: AztecAddress,
@@ -148,8 +142,6 @@ pub contract NFT {
         commitment: Field,
         _nonce: Field,
     ) {
-        _validate_from_private::<4>(self.context, from);
-
         self.internal._remove_private_token_owner(from, token_id);
         let completer = from;
         self.enqueue_self.transfer_token_to_commitment_internal(
@@ -165,6 +157,7 @@ pub contract NFT {
     /// @param to The address of the recipient
     /// @param token_id The id of the token to transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn transfer_public_to_private(
         from: AztecAddress,
@@ -172,8 +165,6 @@ pub contract NFT {
         token_id: Field,
         _nonce: Field,
     ) {
-        _validate_from_private::<4>(self.context, from);
-
         self.enqueue_self.transfer_public_to_private_internal(from, token_id);
         self.internal._update_private_token_owner(to, token_id);
     }
@@ -199,6 +190,7 @@ pub contract NFT {
     /// @param to The address of the recipient
     /// @param token_id The id of the token to transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("public")]
     fn transfer_public_to_public(
         from: AztecAddress,
@@ -206,7 +198,6 @@ pub contract NFT {
         token_id: Field,
         _nonce: Field,
     ) {
-        self.internal._validate_from_public(from);
         self.internal._validate_public_token_owner(from, token_id);
 
         self.internal._update_public_token_owner(to, token_id);
@@ -219,6 +210,7 @@ pub contract NFT {
     /// @param token_id The id of the token to transfer
     /// @param commitment The commitment to use for the transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("public")]
     fn transfer_public_to_commitment(
         from: AztecAddress,
@@ -226,7 +218,6 @@ pub contract NFT {
         commitment: Field,
         _nonce: Field,
     ) {
-        self.internal._validate_from_public(from);
         self.internal._validate_public_token_owner(from, token_id);
 
         self.internal._update_public_token_owner(AztecAddress::zero(), token_id);
@@ -396,10 +387,9 @@ pub contract NFT {
     /// @param from The address of the owner
     /// @param token_id The id of the token to burn
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn burn_private(from: AztecAddress, token_id: Field, _nonce: Field) {
-        _validate_from_private::<3>(self.context, from);
-
         self.internal._remove_private_token_owner(from, token_id);
         self.enqueue_self.burn_private_internal(token_id);
     }
@@ -409,10 +399,9 @@ pub contract NFT {
     /// @param from The address of the owner
     /// @param token_id The id of the token to burn
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("public")]
     fn burn_public(from: AztecAddress, token_id: Field, _nonce: Field) {
-        self.internal._validate_from_public(from);
-
         self.internal._validate_public_token_owner(from, token_id);
         self.internal._update_public_token_owner(AztecAddress::zero(), token_id);
         self.internal._set_nft_exists(token_id, false);
@@ -524,28 +513,5 @@ pub contract NFT {
     #[contract_library_method]
     fn _validate_minter(sender: AztecAddress, minter: AztecAddress) {
         assert(minter.eq(sender), "caller is not minter");
-    }
-
-    /** ==========================================================
-     * ================== AUTH LIBRARIES =========================
-     * ======================================================== */
-
-    /// @notice Validates that the caller possesses authwit from the `from` address or the caller is the `from` address
-    /// @param context The context of the private call
-    /// @param from The address of the sender
-    #[contract_library_method]
-    fn _validate_from_private<let N: u32>(context: &mut PrivateContext, from: AztecAddress) {
-        if (!from.eq(context.maybe_msg_sender().unwrap())) {
-            assert_current_call_valid_authwit::<N>(context, from);
-        }
-    }
-
-    /// @notice Validates that the caller possesses authwit from the `from` address or the caller is the `from` address
-    /// @param from The address of the sender
-    #[internal("public")]
-    fn _validate_from_public(from: AztecAddress) {
-        if (!from.eq(self.msg_sender())) {
-            assert_current_call_valid_authwit_public(self.context, from);
-        }
     }
 }

--- a/src/token_contract/src/main.nr
+++ b/src/token_contract/src/main.nr
@@ -6,13 +6,9 @@ use aztec::macros::aztec;
 pub contract Token {
     // aztec library
     use aztec::{
-        authwit::auth::{
-            assert_current_call_valid_authwit, assert_current_call_valid_authwit_public,
-        },
-        context::PrivateContext,
         macros::{
             events::event,
-            functions::{external, initializer, internal, only_self, view},
+            functions::{authorize_once, external, initializer, internal, only_self, view},
             storage::storage,
         },
         messages::message_delivery::MessageDelivery,
@@ -109,6 +105,7 @@ pub contract Token {
     /// @param to The address of the recipient
     /// @param amount The amount of tokens to transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn transfer_private_to_public(
         from: AztecAddress,
@@ -116,8 +113,6 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
-        _validate_from_private::<4>(self.context, from);
-
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
         self.enqueue_self.increase_public_balance_internal(to, amount);
@@ -131,6 +126,7 @@ pub contract Token {
     /// @param amount The amount of tokens to transfer
     /// @param _nonce The nonce used for authwitness
     /// @return commitment The partial note utilized for the transfer commitment (privacy entrance)
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn transfer_private_to_public_with_commitment(
         from: AztecAddress,
@@ -138,8 +134,6 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) -> Field {
-        _validate_from_private::<4>(self.context, from);
-
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
         self.enqueue_self.increase_public_balance_internal(to, amount);
@@ -156,6 +150,7 @@ pub contract Token {
     /// @param to The address of the recipient
     /// @param amount The amount of tokens to transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn transfer_private_to_private(
         from: AztecAddress,
@@ -163,8 +158,6 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
-        _validate_from_private::<4>(self.context, from);
-
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
         self.internal._increase_private_balance(to, amount);
@@ -177,6 +170,7 @@ pub contract Token {
     /// @param commitment The partial note representing the commitment (privacy entrance that the recipient shares with the sender)
     /// @param amount The amount of tokens to transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn transfer_private_to_commitment(
         from: AztecAddress,
@@ -184,8 +178,6 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
-        _validate_from_private::<4>(self.context, from);
-
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
         let completer = self.msg_sender();
@@ -202,6 +194,7 @@ pub contract Token {
     /// @param to The address of the recipient
     /// @param amount The amount of tokens to transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn transfer_public_to_private(
         from: AztecAddress,
@@ -209,8 +202,6 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
-        _validate_from_private::<4>(self.context, from);
-
         self.enqueue_self.decrease_public_balance_internal(from, amount);
 
         self.internal._increase_private_balance(to, amount);
@@ -248,6 +239,7 @@ pub contract Token {
     /// @param to The address of the recipient
     /// @param amount The amount of tokens to transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("public")]
     fn transfer_public_to_public(
         from: AztecAddress,
@@ -255,8 +247,6 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
-        self.internal._validate_from_public(from);
-
         self.internal._decrease_public_balance(from, amount);
         self.internal._increase_public_balance(to, amount);
 
@@ -271,6 +261,7 @@ pub contract Token {
     /// @param commitment The partial note representing the commitment (privacy entrance)
     /// @param amount The amount of tokens to transfer
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("public")]
     fn transfer_public_to_commitment(
         from: AztecAddress,
@@ -278,8 +269,6 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
-        self.internal._validate_from_public(from);
-
         self.internal._decrease_public_balance(from, amount);
 
         let completer = self.msg_sender();
@@ -434,10 +423,9 @@ pub contract Token {
     /// @param from The address of the sender
     /// @param amount The amount of tokens to burn
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn burn_private(from: AztecAddress, amount: u128, _nonce: Field) {
-        _validate_from_private::<3>(self.context, from);
-
         self.internal._burn_private(from, amount);
     }
 
@@ -446,10 +434,9 @@ pub contract Token {
     /// @param from The address of the sender
     /// @param amount The amount of tokens to burn
     /// @param _nonce The nonce used for authwitness
+    #[authorize_once("from", "_nonce")]
     #[external("public")]
     fn burn_public(from: AztecAddress, amount: u128, _nonce: Field) {
-        self.internal._validate_from_public(from);
-
         self.internal._burn_public(from, amount);
     }
 
@@ -632,30 +619,6 @@ pub contract Token {
     fn _burn_private(from: AztecAddress, amount: u128) {
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
         self.enqueue_self.decrease_total_supply_internal(amount);
-    }
-
-    /** ==========================================================
-     * ================== AUTH LIBRARIES =========================
-     * ======================================================== */
-
-    /// @notice Validates that the caller possesses authwit from the `from` address or the caller is the `from` address
-    /// @param context The context of the private call
-    /// @param from The address of the sender
-    #[contract_library_method]
-    fn _validate_from_private<let N: u32>(context: &mut PrivateContext, from: AztecAddress) {
-        if (!from.eq(context.maybe_msg_sender().unwrap())) {
-            assert_current_call_valid_authwit::<N>(context, from);
-        }
-    }
-
-    /// @notice Validates that the caller possesses authwit from the `from` address or the caller is the `from` address
-    /// @param context The context of the public call
-    /// @param from The address of the sender
-    #[internal("public")]
-    fn _validate_from_public(from: AztecAddress) {
-        if (!from.eq(self.msg_sender())) {
-            assert_current_call_valid_authwit_public(self.context, from);
-        }
     }
 
 }

--- a/src/vault_contract/src/main.nr
+++ b/src/vault_contract/src/main.nr
@@ -5,10 +5,11 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract Vault {
     use aztec::{
-        macros::{
-            functions::{authorize_once, external, initializer, internal, only_self, view},
-            storage::storage,
+        authwit::auth::{
+            assert_current_call_valid_authwit, assert_current_call_valid_authwit_public,
         },
+        context::PrivateContext,
+        macros::{functions::{external, initializer, internal, only_self, view}, storage::storage},
         protocol::address::AztecAddress,
         state_vars::PublicImmutable,
     };
@@ -133,11 +134,11 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param assets The amount of assets to deposit
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("public")]
     fn deposit_public_to_public(from: AztecAddress, to: AztecAddress, assets: u128, nonce: Field) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
+        self.internal._validate_from_public(from);
 
         // Calculate shares to mint
         let total_assets = self.internal._total_assets();
@@ -168,7 +169,6 @@ pub contract Vault {
     /// @param assets The amount of assets to deposit
     /// @param shares The amount of shares that should be minted to the recipient
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn deposit_public_to_private(
         from: AztecAddress,
@@ -178,6 +178,7 @@ pub contract Vault {
         nonce: Field,
     ) {
         let shares_token = self.storage.shares.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Validate in public that `assets` is sufficient for the requested shares
         // Order matters: enqueue settlement first so asset transfer executes before shares total_supply increase
@@ -195,7 +196,6 @@ pub contract Vault {
     /// @param assets The amount of assets to deposit
     /// @param shares The amount of shares that should be minted to the recipient
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn deposit_private_to_private(
         from: AztecAddress,
@@ -206,6 +206,7 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Order matters: transfer before minting to neutralize ARC-403 reentrancy.
         // Take the assets from the sender
@@ -228,10 +229,10 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param assets The amount of assets to deposit
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn deposit_private_to_public(from: AztecAddress, to: AztecAddress, assets: u128, nonce: Field) {
         let asset_token = self.storage.asset.read();
+        _validate_from_private::<4>(self.context, from);
 
         // Order matters: transfer before minting to neutralize ARC-403 reentrancy.
         // Take the assets from the sender
@@ -255,7 +256,6 @@ pub contract Vault {
     /// @param assets The amount of assets to deposit
     /// @param min_shares The amount of shares that should be minted to the recipient in private
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn deposit_public_to_private_exact(
         from: AztecAddress,
@@ -265,6 +265,7 @@ pub contract Vault {
         nonce: Field,
     ) {
         let shares_token = self.storage.shares.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the shares token that allows to mint outstanding shares to the recipient in public
         let partial_note =
@@ -294,7 +295,6 @@ pub contract Vault {
     /// @param assets The amount of assets to deposit
     /// @param min_shares The amount of shares that should be minted to the recipient in private
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn deposit_private_to_private_exact(
         from: AztecAddress,
@@ -305,6 +305,7 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the shares token that allows to mint outstanding shares to the recipient in public
         let partial_note =
@@ -341,7 +342,6 @@ pub contract Vault {
     /// @param shares The amount of shares to issue
     /// @param max_assets The maximum amount of assets that should be deposited
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("public")]
     fn issue_public_to_public(
         from: AztecAddress,
@@ -352,6 +352,7 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
+        self.internal._validate_from_public(from);
 
         // Calculate assets required
         let total_assets = self.internal._total_assets();
@@ -389,7 +390,6 @@ pub contract Vault {
     /// @param shares The amount of shares to issue
     /// @param max_assets The maximum amount of assets that should be deposited
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn issue_public_to_private(
         from: AztecAddress,
@@ -400,6 +400,7 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Order matters: enqueue asset transfer first so it executes before shares total_supply increase,
         // neutralizing ARC-403 reentrancy.
@@ -424,7 +425,6 @@ pub contract Vault {
     /// @param shares The amount of shares to issue
     /// @param max_assets The maximum amount of assets that should be deposited
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn issue_private_to_public_exact(
         from: AztecAddress,
@@ -434,6 +434,7 @@ pub contract Vault {
         nonce: Field,
     ) {
         let asset_token = self.storage.asset.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the asset token that allows to refund excess assets to the sender in public
         let asset_commitment =
@@ -464,7 +465,6 @@ pub contract Vault {
     /// @param shares The amount of shares to issue
     /// @param max_assets The maximum amount of assets that should be deposited
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn issue_private_to_private_exact(
         from: AztecAddress,
@@ -475,6 +475,7 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the asset token that allows to refund excess assets to the sender in public
         let asset_commitment =
@@ -510,11 +511,11 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param assets The amount of assets to withdraw
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("public")]
     fn withdraw_public_to_public(from: AztecAddress, to: AztecAddress, assets: u128, nonce: Field) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
+        self.internal._validate_from_public(from);
 
         // Calculate shares to burn
         let total_assets = self.internal._total_assets();
@@ -536,7 +537,6 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param assets The amount of assets to withdraw
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn withdraw_public_to_private(
         from: AztecAddress,
@@ -545,6 +545,7 @@ pub contract Vault {
         nonce: Field,
     ) {
         let asset_token = self.storage.asset.read();
+        _validate_from_private::<4>(self.context, from);
 
         // Order matters: burn after calculating shares in public to neutralize ARC-403 reentrancy.
         // Calculate and burn the sender's shares
@@ -562,7 +563,6 @@ pub contract Vault {
     /// @param assets The amount of assets to withdraw
     /// @param shares The amount of shares to burn
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn withdraw_private_to_private(
         from: AztecAddress,
@@ -573,6 +573,7 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Burn shares from the sender's private balance on the shares token
         self.call(Token::at(shares_token).burn_private(from, shares, nonce));
@@ -594,7 +595,6 @@ pub contract Vault {
     /// @param assets The amount of underlying asset to withdraw
     /// @param max_shares The maximum amount of shares to burn
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn withdraw_private_to_public_exact(
         from: AztecAddress,
@@ -604,6 +604,7 @@ pub contract Vault {
         nonce: Field,
     ) {
         let shares_token = self.storage.shares.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the shares token that allows to refund excess shares to the sender in public
         let partial_note =
@@ -632,7 +633,6 @@ pub contract Vault {
     /// @param assets The amount of underlying asset to withdraw
     /// @param max_shares The maximum amount of shares to burn
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn withdraw_private_to_private_exact(
         from: AztecAddress,
@@ -643,6 +643,7 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the shares token that allows to refund excess shares to the sender in public
         let partial_note =
@@ -675,11 +676,11 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param shares The amount of shares to redeem
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("public")]
     fn redeem_public_to_public(from: AztecAddress, to: AztecAddress, shares: u128, nonce: Field) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
+        self.internal._validate_from_public(from);
 
         // Calculate assets to redeem
         let total_assets = self.internal._total_assets();
@@ -702,10 +703,10 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param shares The amount of shares to redeem
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn redeem_private_to_public(from: AztecAddress, to: AztecAddress, shares: u128, nonce: Field) {
         let shares_token = self.storage.shares.read();
+        _validate_from_private::<4>(self.context, from);
 
         // Burn shares from the sender's private balance on the shares token
         self.call(Token::at(shares_token).burn_private(from, shares, nonce));
@@ -723,7 +724,6 @@ pub contract Vault {
     /// @param shares The amount of shares to burn
     /// @param min_assets The minimum amount of assets to withdraw, immediately in private
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn redeem_private_to_private_exact(
         from: AztecAddress,
@@ -734,6 +734,7 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the asset token that allows to transfer outstanding assets to the recipient in public
         let asset_commitment =
@@ -764,7 +765,6 @@ pub contract Vault {
     /// @param shares The amount of shares to redeem
     /// @param min_assets The minimum amount of assets to withdraw, immediately in private
     /// @param nonce The nonce used for authwitness
-    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn redeem_public_to_private_exact(
         from: AztecAddress,
@@ -774,6 +774,7 @@ pub contract Vault {
         nonce: Field,
     ) {
         let asset_token = self.storage.asset.read();
+        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the asset token that allows to transfer outstanding assets to the recipient in public
         let asset_commitment =
@@ -1479,4 +1480,23 @@ pub contract Vault {
         assets
     }
 
+    /** ==========================================================
+     * ================= AUTH LIBRARIES =========================
+     * ======================================================== */
+
+    /// @notice Validates that the caller possesses authwit from the `from` address or the caller is the `from` address
+    #[contract_library_method]
+    fn _validate_from_private<let N: u32>(context: &mut PrivateContext, from: AztecAddress) {
+        if (!from.eq(context.maybe_msg_sender().unwrap())) {
+            assert_current_call_valid_authwit::<N>(context, from);
+        }
+    }
+
+    /// @notice Validates that the caller possesses authwit from the `from` address or the caller is the `from` address
+    #[internal("public")]
+    fn _validate_from_public(from: AztecAddress) {
+        if (!from.eq(self.msg_sender())) {
+            assert_current_call_valid_authwit_public(self.context, from);
+        }
+    }
 }

--- a/src/vault_contract/src/main.nr
+++ b/src/vault_contract/src/main.nr
@@ -5,11 +5,10 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract Vault {
     use aztec::{
-        authwit::auth::{
-            assert_current_call_valid_authwit, assert_current_call_valid_authwit_public,
+        macros::{
+            functions::{authorize_once, external, initializer, internal, only_self, view},
+            storage::storage,
         },
-        context::PrivateContext,
-        macros::{functions::{external, initializer, internal, only_self, view}, storage::storage},
         protocol::address::AztecAddress,
         state_vars::PublicImmutable,
     };
@@ -134,11 +133,11 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param assets The amount of assets to deposit
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("public")]
     fn deposit_public_to_public(from: AztecAddress, to: AztecAddress, assets: u128, nonce: Field) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
-        self.internal._validate_from_public(from);
 
         // Calculate shares to mint
         let total_assets = self.internal._total_assets();
@@ -169,6 +168,7 @@ pub contract Vault {
     /// @param assets The amount of assets to deposit
     /// @param shares The amount of shares that should be minted to the recipient
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn deposit_public_to_private(
         from: AztecAddress,
@@ -178,7 +178,6 @@ pub contract Vault {
         nonce: Field,
     ) {
         let shares_token = self.storage.shares.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Validate in public that `assets` is sufficient for the requested shares
         // Order matters: enqueue settlement first so asset transfer executes before shares total_supply increase
@@ -196,6 +195,7 @@ pub contract Vault {
     /// @param assets The amount of assets to deposit
     /// @param shares The amount of shares that should be minted to the recipient
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn deposit_private_to_private(
         from: AztecAddress,
@@ -206,7 +206,6 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Order matters: transfer before minting to neutralize ARC-403 reentrancy.
         // Take the assets from the sender
@@ -229,10 +228,10 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param assets The amount of assets to deposit
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn deposit_private_to_public(from: AztecAddress, to: AztecAddress, assets: u128, nonce: Field) {
         let asset_token = self.storage.asset.read();
-        _validate_from_private::<4>(self.context, from);
 
         // Order matters: transfer before minting to neutralize ARC-403 reentrancy.
         // Take the assets from the sender
@@ -256,6 +255,7 @@ pub contract Vault {
     /// @param assets The amount of assets to deposit
     /// @param min_shares The amount of shares that should be minted to the recipient in private
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn deposit_public_to_private_exact(
         from: AztecAddress,
@@ -265,7 +265,6 @@ pub contract Vault {
         nonce: Field,
     ) {
         let shares_token = self.storage.shares.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the shares token that allows to mint outstanding shares to the recipient in public
         let partial_note =
@@ -295,6 +294,7 @@ pub contract Vault {
     /// @param assets The amount of assets to deposit
     /// @param min_shares The amount of shares that should be minted to the recipient in private
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn deposit_private_to_private_exact(
         from: AztecAddress,
@@ -305,7 +305,6 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the shares token that allows to mint outstanding shares to the recipient in public
         let partial_note =
@@ -342,6 +341,7 @@ pub contract Vault {
     /// @param shares The amount of shares to issue
     /// @param max_assets The maximum amount of assets that should be deposited
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("public")]
     fn issue_public_to_public(
         from: AztecAddress,
@@ -352,7 +352,6 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
-        self.internal._validate_from_public(from);
 
         // Calculate assets required
         let total_assets = self.internal._total_assets();
@@ -390,6 +389,7 @@ pub contract Vault {
     /// @param shares The amount of shares to issue
     /// @param max_assets The maximum amount of assets that should be deposited
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn issue_public_to_private(
         from: AztecAddress,
@@ -400,7 +400,6 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Order matters: enqueue asset transfer first so it executes before shares total_supply increase,
         // neutralizing ARC-403 reentrancy.
@@ -425,6 +424,7 @@ pub contract Vault {
     /// @param shares The amount of shares to issue
     /// @param max_assets The maximum amount of assets that should be deposited
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn issue_private_to_public_exact(
         from: AztecAddress,
@@ -434,7 +434,6 @@ pub contract Vault {
         nonce: Field,
     ) {
         let asset_token = self.storage.asset.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the asset token that allows to refund excess assets to the sender in public
         let asset_commitment =
@@ -465,6 +464,7 @@ pub contract Vault {
     /// @param shares The amount of shares to issue
     /// @param max_assets The maximum amount of assets that should be deposited
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn issue_private_to_private_exact(
         from: AztecAddress,
@@ -475,7 +475,6 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the asset token that allows to refund excess assets to the sender in public
         let asset_commitment =
@@ -511,11 +510,11 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param assets The amount of assets to withdraw
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("public")]
     fn withdraw_public_to_public(from: AztecAddress, to: AztecAddress, assets: u128, nonce: Field) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
-        self.internal._validate_from_public(from);
 
         // Calculate shares to burn
         let total_assets = self.internal._total_assets();
@@ -537,6 +536,7 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param assets The amount of assets to withdraw
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn withdraw_public_to_private(
         from: AztecAddress,
@@ -545,7 +545,6 @@ pub contract Vault {
         nonce: Field,
     ) {
         let asset_token = self.storage.asset.read();
-        _validate_from_private::<4>(self.context, from);
 
         // Order matters: burn after calculating shares in public to neutralize ARC-403 reentrancy.
         // Calculate and burn the sender's shares
@@ -563,6 +562,7 @@ pub contract Vault {
     /// @param assets The amount of assets to withdraw
     /// @param shares The amount of shares to burn
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn withdraw_private_to_private(
         from: AztecAddress,
@@ -573,7 +573,6 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Burn shares from the sender's private balance on the shares token
         self.call(Token::at(shares_token).burn_private(from, shares, nonce));
@@ -595,6 +594,7 @@ pub contract Vault {
     /// @param assets The amount of underlying asset to withdraw
     /// @param max_shares The maximum amount of shares to burn
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn withdraw_private_to_public_exact(
         from: AztecAddress,
@@ -604,7 +604,6 @@ pub contract Vault {
         nonce: Field,
     ) {
         let shares_token = self.storage.shares.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the shares token that allows to refund excess shares to the sender in public
         let partial_note =
@@ -633,6 +632,7 @@ pub contract Vault {
     /// @param assets The amount of underlying asset to withdraw
     /// @param max_shares The maximum amount of shares to burn
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn withdraw_private_to_private_exact(
         from: AztecAddress,
@@ -643,7 +643,6 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the shares token that allows to refund excess shares to the sender in public
         let partial_note =
@@ -676,11 +675,11 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param shares The amount of shares to redeem
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("public")]
     fn redeem_public_to_public(from: AztecAddress, to: AztecAddress, shares: u128, nonce: Field) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
-        self.internal._validate_from_public(from);
 
         // Calculate assets to redeem
         let total_assets = self.internal._total_assets();
@@ -703,10 +702,10 @@ pub contract Vault {
     /// @param to The address of the recipient
     /// @param shares The amount of shares to redeem
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn redeem_private_to_public(from: AztecAddress, to: AztecAddress, shares: u128, nonce: Field) {
         let shares_token = self.storage.shares.read();
-        _validate_from_private::<4>(self.context, from);
 
         // Burn shares from the sender's private balance on the shares token
         self.call(Token::at(shares_token).burn_private(from, shares, nonce));
@@ -724,6 +723,7 @@ pub contract Vault {
     /// @param shares The amount of shares to burn
     /// @param min_assets The minimum amount of assets to withdraw, immediately in private
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn redeem_private_to_private_exact(
         from: AztecAddress,
@@ -734,7 +734,6 @@ pub contract Vault {
     ) {
         let asset_token = self.storage.asset.read();
         let shares_token = self.storage.shares.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the asset token that allows to transfer outstanding assets to the recipient in public
         let asset_commitment =
@@ -765,6 +764,7 @@ pub contract Vault {
     /// @param shares The amount of shares to redeem
     /// @param min_assets The minimum amount of assets to withdraw, immediately in private
     /// @param nonce The nonce used for authwitness
+    #[authorize_once("from", "nonce")]
     #[external("private")]
     fn redeem_public_to_private_exact(
         from: AztecAddress,
@@ -774,7 +774,6 @@ pub contract Vault {
         nonce: Field,
     ) {
         let asset_token = self.storage.asset.read();
-        _validate_from_private::<5>(self.context, from);
 
         // Initialize commitment on the asset token that allows to transfer outstanding assets to the recipient in public
         let asset_commitment =
@@ -1480,23 +1479,4 @@ pub contract Vault {
         assets
     }
 
-    /** ==========================================================
-     * ================= AUTH LIBRARIES =========================
-     * ======================================================== */
-
-    /// @notice Validates that the caller possesses authwit from the `from` address or the caller is the `from` address
-    #[contract_library_method]
-    fn _validate_from_private<let N: u32>(context: &mut PrivateContext, from: AztecAddress) {
-        if (!from.eq(context.maybe_msg_sender().unwrap())) {
-            assert_current_call_valid_authwit::<N>(context, from);
-        }
-    }
-
-    /// @notice Validates that the caller possesses authwit from the `from` address or the caller is the `from` address
-    #[internal("public")]
-    fn _validate_from_public(from: AztecAddress) {
-        if (!from.eq(self.msg_sender())) {
-            assert_current_call_valid_authwit_public(self.context, from);
-        }
-    }
 }


### PR DESCRIPTION
# 🤖 Linear

Closes AZT-XXX

## Description 

  - Replace manual `_validate_from_private` and `_validate_from_public` authwit validation calls with the `#[authorize_once]` macro attribute across all contracts
  - Remove `_validate_from_private` (contract_library_method) and `_validate_from_public` (internal public) function definitions from token, NFT, and vault contracts
  - Clean up unused imports (`assert_current_call_valid_authwit`, `assert_current_call_valid_authwit_public`, `PrivateContext`)