### PR TITLE
feat: public and private supply

### DIFF
--- a/src/token_contract/src/main.nr
+++ b/src/token_contract/src/main.nr
@@ -117,7 +117,7 @@ pub contract Token {
     ) {
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
-        self.enqueue_self.increase_public_balance_and_supply_internal(to, amount);
+        self.enqueue_self.increase_public_balance_and_public_supply_internal(to, amount);
     }
 
     /// @notice Transfer tokens from private balance to public balance and initializes a commitment
@@ -138,7 +138,7 @@ pub contract Token {
     ) -> Field {
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
-        self.enqueue_self.increase_public_balance_and_supply_internal(to, amount);
+        self.enqueue_self.increase_public_balance_and_public_supply_internal(to, amount);
 
         // Only the sender will be able to complete the partial note
         let completer = self.msg_sender();
@@ -290,7 +290,7 @@ pub contract Token {
     /// @param amount The amount of tokens to increase the balance by
     #[external("public")]
     #[only_self]
-    fn increase_public_balance_and_supply_internal(to: AztecAddress, amount: u128) {
+    fn increase_public_balance_and_public_supply_internal(to: AztecAddress, amount: u128) {
         self.internal._increase_public_balance(to, amount);
         self.internal._increase_public_supply(amount);
 

--- a/src/token_contract/src/main.nr
+++ b/src/token_contract/src/main.nr
@@ -46,6 +46,7 @@ pub contract Token {
     /// @param total_supply The total supply of the token
     /// @param public_balances The public balances of the token
     /// @param minter The account permissioned to mint the token
+    /// @param public_supply The total supply of the token that are public
     #[storage]
     struct Storage<Context> {
         name: PublicImmutable<FieldCompressedString, Context>,
@@ -55,6 +56,7 @@ pub contract Token {
         total_supply: PublicMutable<u128, Context>,
         public_balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
         minter: PublicImmutable<AztecAddress, Context>,
+        public_supply: PublicMutable<u128, Context>,
     }
 
     /// @notice Initializes the token with an initial supply
@@ -115,7 +117,7 @@ pub contract Token {
     ) {
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
-        self.enqueue_self.increase_public_balance_internal(to, amount);
+        self.enqueue_self.increase_public_balance_and_supply_internal(to, amount);
     }
 
     /// @notice Transfer tokens from private balance to public balance and initializes a commitment
@@ -136,7 +138,7 @@ pub contract Token {
     ) -> Field {
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
-        self.enqueue_self.increase_public_balance_internal(to, amount);
+        self.enqueue_self.increase_public_balance_and_supply_internal(to, amount);
 
         // Only the sender will be able to complete the partial note
         let completer = self.msg_sender();
@@ -203,7 +205,7 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
-        self.enqueue_self.decrease_public_balance_internal(from, amount);
+        self.enqueue_self.decrease_public_balance_and_supply_internal(from, amount);
 
         self.internal._increase_private_balance(to, amount);
     }
@@ -271,6 +273,7 @@ pub contract Token {
         _nonce: Field,
     ) {
         self.internal._decrease_public_balance(from, amount);
+        self.internal._decrease_public_supply(amount);
 
         let completer = self.msg_sender();
         self.internal._increase_commitment_balance(
@@ -282,24 +285,26 @@ pub contract Token {
         self.emit(Transfer { from, to: PRIVATE_ADDRESS_MAGIC_VALUE, amount });
     }
 
-    /// @notice Increases the public balance of `to` by `amount`
+    /// @notice Increases the public balance of `to` by `amount` and updates the public supply
     /// @param to The address of the recipient
     /// @param amount The amount of tokens to increase the balance by
     #[external("public")]
     #[only_self]
-    fn increase_public_balance_internal(to: AztecAddress, amount: u128) {
+    fn increase_public_balance_and_supply_internal(to: AztecAddress, amount: u128) {
         self.internal._increase_public_balance(to, amount);
+        self.internal._increase_public_supply(amount);
 
         self.emit(Transfer { from: PRIVATE_ADDRESS_MAGIC_VALUE, to, amount });
     }
 
-    /// @notice Decreases the public balance of `from` by `amount`
+    /// @notice Decreases the public balance of `from` by `amount` and updates the public supply
     /// @param from The address of the sender
     /// @param amount The amount of tokens to decrease the balance by
     #[external("public")]
     #[only_self]
-    fn decrease_public_balance_internal(from: AztecAddress, amount: u128) {
+    fn decrease_public_balance_and_supply_internal(from: AztecAddress, amount: u128) {
         self.internal._decrease_public_balance(from, amount);
+        self.internal._decrease_public_supply(amount);
 
         self.emit(Transfer { from, to: PRIVATE_ADDRESS_MAGIC_VALUE, amount });
     }
@@ -323,6 +328,22 @@ pub contract Token {
     #[view]
     fn total_supply() -> u128 {
         self.storage.total_supply.read()
+    }
+
+    /// @notice Returns the public total supply of the token
+    /// @return The public total supply of the token
+    #[external("public")]
+    #[view]
+    fn public_supply() -> u128 {
+        self.storage.public_supply.read()
+    }
+
+    /// @notice Returns the private total supply of the token
+    /// @return The private total supply of the token
+    #[external("public")]
+    #[view]
+    fn private_supply() -> u128 {
+        self.storage.total_supply.read() - self.storage.public_supply.read()
     }
 
     /// @notice Returns the name of the token
@@ -567,6 +588,22 @@ pub contract Token {
         self.storage.total_supply.write(new_supply);
     }
 
+    /// @notice Increases the public supply by `amount`
+    /// @param amount The amount of tokens to increase the public supply by
+    #[internal("public")]
+    fn _increase_public_supply(amount: u128) {
+        let new_supply = self.storage.public_supply.read() + amount;
+        self.storage.public_supply.write(new_supply);
+    }
+
+    /// @notice Decreases the public supply by `amount`
+    /// @param amount The amount to decrease the public supply by
+    #[internal("public")]
+    fn _decrease_public_supply(amount: u128) {
+        let new_supply = self.storage.public_supply.read() - amount;
+        self.storage.public_supply.write(new_supply);
+    }
+
     /// @notice Initializes a transfer commitment to be used for transfers/mints
     /// @param to The address of the recipient
     /// @param completer The address used to compute the validity commitment
@@ -581,13 +618,14 @@ pub contract Token {
         commitment
     }
 
-    /// @notice Mints tokens to a public balance and increases the total supply
+    /// @notice Mints tokens to a public balance and increases the total supply and public supply
     /// @param to The address of the recipient
     /// @param amount The amount of tokens to mint
     #[internal("public")]
     fn _mint_to_public(to: AztecAddress, amount: u128) {
         self.internal._increase_public_balance(to, amount);
         self.internal._increase_total_supply(amount);
+        self.internal._increase_public_supply(amount);
 
         self.emit(Transfer { from: AztecAddress::zero(), to, amount });
     }
@@ -601,13 +639,14 @@ pub contract Token {
         self.enqueue_self.increase_total_supply_internal(amount);
     }
 
-    /// @notice Burns tokens from a public balance and decreases the total supply
+    /// @notice Burns tokens from a public balance and decreases the total supply and public supply
     /// @param from The address to burn tokens from
     /// @param amount The amount of tokens to burn
     #[internal("public")]
     fn _burn_public(from: AztecAddress, amount: u128) {
         self.internal._decrease_public_balance(from, amount);
         self.internal._decrease_total_supply(amount);
+        self.internal._decrease_public_supply(amount);
 
         self.emit(Transfer { from, to: AztecAddress::zero(), amount });
     }

--- a/src/token_contract/src/test/burn_private.nr
+++ b/src/token_contract/src/test/burn_private.nr
@@ -17,6 +17,7 @@ unconstrained fn burn_private_on_behalf_of_self() {
         owner,
         mint_amount - burn_amount,
     );
+    utils::assert_supply(env, token_contract_address, 0, mint_amount - burn_amount);
 }
 
 #[test]
@@ -44,6 +45,7 @@ unconstrained fn burn_private_on_behalf_of_other() {
         owner,
         mint_amount - burn_amount,
     );
+    utils::assert_supply(env, token_contract_address, 0, mint_amount - burn_amount);
 }
 
 #[test(should_fail_with = "Balance too low")]

--- a/src/token_contract/src/test/burn_public.nr
+++ b/src/token_contract/src/test/burn_public.nr
@@ -16,6 +16,7 @@ unconstrained fn burn_public_success() {
         owner,
         mint_amount - burn_amount,
     );
+    utils::assert_supply(env, token_contract_address, mint_amount - burn_amount, 0);
 }
 
 #[test]
@@ -24,7 +25,7 @@ unconstrained fn burn_public_decrease_total_supply() {
         utils::setup_and_mint_to_public_without_minter(false);
     let burn_amount = mint_amount / 10 as u128;
 
-    utils::check_total_supply(env, token_contract_address, mint_amount);
+    utils::assert_supply(env, token_contract_address, mint_amount, 0);
 
     // Burn less than balance
     env.call_public(owner, Token::at(token_contract_address).burn_public(owner, burn_amount, 0));
@@ -34,7 +35,7 @@ unconstrained fn burn_public_decrease_total_supply() {
         owner,
         mint_amount - burn_amount,
     );
-    utils::check_total_supply(env, token_contract_address, mint_amount - burn_amount);
+    utils::assert_supply(env, token_contract_address, mint_amount - burn_amount, 0);
 }
 
 #[test]
@@ -55,6 +56,7 @@ unconstrained fn burn_public_on_behalf_of_other() {
         owner,
         mint_amount - burn_amount,
     );
+    utils::assert_supply(env, token_contract_address, mint_amount - burn_amount, 0);
 }
 
 #[test(should_fail_with = "attempt to subtract with overflow 'self.storage.public_balances.at(from).read() - amount'")]

--- a/src/token_contract/src/test/mint_to_commitment.nr
+++ b/src/token_contract/src/test/mint_to_commitment.nr
@@ -18,9 +18,7 @@ unconstrained fn mint_to_commitment_success() {
     );
 
     utils::check_private_balance(env, token_contract_address, recipient, mint_amount);
-
-    let total_supply = env.view_public(Token::at(token_contract_address).total_supply());
-    assert(total_supply == mint_amount);
+    utils::assert_supply(env, token_contract_address, 0, mint_amount);
 }
 
 #[test(should_fail_with = "caller is not minter")]

--- a/src/token_contract/src/test/mint_to_private.nr
+++ b/src/token_contract/src/test/mint_to_private.nr
@@ -9,9 +9,7 @@ unconstrained fn mint_to_private_success() {
     env.call_private(minter, Token::at(token_contract_address).mint_to_private(owner, mint_amount));
 
     utils::check_private_balance(env, token_contract_address, owner, mint_amount);
-
-    let total_supply = env.view_public(Token::at(token_contract_address).total_supply());
-    assert(total_supply == mint_amount);
+    utils::assert_supply(env, token_contract_address, 0, mint_amount);
 }
 
 #[test(should_fail_with = "Assertion failed: caller is not minter")]

--- a/src/token_contract/src/test/mint_to_public.nr
+++ b/src/token_contract/src/test/mint_to_public.nr
@@ -11,9 +11,7 @@ unconstrained fn mint_to_public_success() {
     env.call_public(minter, token.mint_to_public(owner, mint_amount));
 
     utils::check_public_balance(env, token_contract_address, owner, mint_amount);
-
-    let total_supply = env.view_public(token.total_supply());
-    assert(total_supply == mint_amount);
+    utils::assert_supply(env, token_contract_address, mint_amount, 0);
 }
 
 #[test(should_fail_with = "Contract execution has reverted: Assertion failed: caller is not minter 'minter.eq(sender)'")]

--- a/src/token_contract/src/test/transfer_private_to_commitment.nr
+++ b/src/token_contract/src/test/transfer_private_to_commitment.nr
@@ -32,6 +32,7 @@ unconstrained fn transfer_private_to_commitment() {
     // Check balances
     utils::check_private_balance(env, token_contract_address, owner, 0 as u128);
     utils::check_private_balance(env, token_contract_address, recipient, transfer_amount);
+    utils::assert_supply(env, token_contract_address, 0, mint_amount);
 }
 
 #[test]
@@ -74,6 +75,7 @@ unconstrained fn transfer_private_to_commitment_on_behalf_of_other() {
     // Check balances
     utils::check_private_balance(env, token_contract_address, owner, 0 as u128);
     utils::check_private_balance(env, token_contract_address, recipient, transfer_amount);
+    utils::assert_supply(env, token_contract_address, 0, mint_amount);
 }
 
 #[test(should_fail_with = "Nullifier witness not found for nullifier")]

--- a/src/token_contract/src/test/transfer_private_to_private.nr
+++ b/src/token_contract/src/test/transfer_private_to_private.nr
@@ -36,6 +36,7 @@ unconstrained fn transfer_private_on_behalf_of_other() {
         mint_amount - transfer_amount,
     );
     utils::check_private_balance(env, token_contract_address, recipient, transfer_amount);
+    utils::assert_supply(env, token_contract_address, 0, mint_amount);
 }
 
 #[test]
@@ -51,6 +52,7 @@ unconstrained fn transfer_private_zero_amount() {
     // Check balances
     utils::check_private_balance(env, token_contract_address, owner, mint_amount);
     utils::check_private_balance(env, token_contract_address, recipient, 0);
+    utils::assert_supply(env, token_contract_address, 0, mint_amount);
 }
 
 #[test]
@@ -100,6 +102,7 @@ unconstrained fn transfer_private_multiple_notes_recursively() {
         total_amount - transfer_amount,
     );
     utils::check_private_balance(env, token_contract_address, recipient, transfer_amount);
+    utils::assert_supply(env, token_contract_address, 0, total_amount);
 }
 
 #[test(should_fail_with = "Balance too low")]

--- a/src/token_contract/src/test/transfer_private_to_public.nr
+++ b/src/token_contract/src/test/transfer_private_to_public.nr
@@ -32,6 +32,12 @@ unconstrained fn transfer_private_to_public_on_behalf_of_self() {
         owner,
         transfer_private_to_public_amount,
     );
+    utils::assert_supply(
+        env,
+        token_contract_address,
+        transfer_private_to_public_amount,
+        mint_amount - transfer_private_to_public_amount,
+    );
 }
 
 #[test]
@@ -68,6 +74,12 @@ unconstrained fn transfer_private_to_public_on_behalf_of_other() {
         token_contract_address,
         recipient,
         transfer_private_to_public_amount,
+    );
+    utils::assert_supply(
+        env,
+        token_contract_address,
+        transfer_private_to_public_amount,
+        mint_amount - transfer_private_to_public_amount,
     );
 }
 
@@ -116,6 +128,12 @@ unconstrained fn transfer_private_to_public_multiple_notes_recursively() {
         total_amount - transfer_amount,
     );
     utils::check_public_balance(env, token_contract_address, recipient, transfer_amount);
+    utils::assert_supply(
+        env,
+        token_contract_address,
+        transfer_amount,
+        total_amount - transfer_amount,
+    );
 }
 
 #[test(should_fail_with = "Balance too low")]

--- a/src/token_contract/src/test/transfer_private_to_public_with_commitment.nr
+++ b/src/token_contract/src/test/transfer_private_to_public_with_commitment.nr
@@ -28,6 +28,7 @@ unconstrained fn transfer_private_to_public_with_commitment() {
     // Check balances
     utils::check_private_balance(env, token_contract_address, owner, 0 as u128);
     utils::check_public_balance(env, token_contract_address, recipient, transfer_amount);
+    utils::assert_supply(env, token_contract_address, transfer_amount, 0);
 }
 
 #[test]
@@ -90,6 +91,7 @@ unconstrained fn transfer_private_to_public_with_commitment_on_behalf_of_other()
     // Check balances
     utils::check_private_balance(env, token_contract_address, owner, 0 as u128);
     utils::check_public_balance(env, token_contract_address, recipient, transfer_amount);
+    utils::assert_supply(env, token_contract_address, transfer_amount, 0);
 }
 
 #[test]
@@ -129,6 +131,7 @@ unconstrained fn transfer_private_to_public_with_commitment_and_finalize() {
     utils::check_private_balance(env, token_contract_address, owner, 0 as u128);
     utils::check_public_balance(env, token_contract_address, recipient, 0 as u128);
     utils::check_private_balance(env, token_contract_address, recipient, transfer_amount);
+    utils::assert_supply(env, token_contract_address, 0, transfer_amount);
 }
 
 #[test(should_fail_with = "Invalid partial note or completer")]

--- a/src/token_contract/src/test/transfer_public_to_commitment.nr
+++ b/src/token_contract/src/test/transfer_public_to_commitment.nr
@@ -16,6 +16,7 @@ unconstrained fn transfer_public_to_commitment_internal_orchestration() {
 
     // User's private balance should be equal to the amount
     utils::check_private_balance(env, token_contract_address, user, mint_amount);
+    utils::assert_supply(env, token_contract_address, 0, mint_amount);
 }
 
 /// External orchestration means that the calls to prepare and finalize are not done by the Token contract. This flow
@@ -51,6 +52,7 @@ unconstrained fn transfer_public_to_commitment_external_orchestration() {
 
     // Recipient's private balance should be equal to the amount
     utils::check_private_balance(env, token_contract_address, recipient, mint_amount);
+    utils::assert_supply(env, token_contract_address, 0, mint_amount);
 }
 
 #[test(should_fail_with = "Invalid partial note or completer 'context.nullifier_exists_unsafe(validity_commitment, context.this_address())'")]

--- a/src/token_contract/src/test/transfer_public_to_private.nr
+++ b/src/token_contract/src/test/transfer_public_to_private.nr
@@ -30,8 +30,14 @@ unconstrained fn transfer_public_to_private_success() {
             == transfer_amount,
         "public balance is not correct",
     );
-    // recipient private balance incre ases
+    // recipient private balance increases
     utils::check_private_balance(env, token_contract_address, recipient, transfer_amount);
+    utils::assert_supply(
+        env,
+        token_contract_address,
+        transfer_amount,
+        transfer_amount,
+    );
 }
 
 #[test(should_fail_with = "Assertion failed: attempt to subtract with overflow 'self.storage.public_balances.at(from).read() - amount'")]
@@ -85,6 +91,12 @@ unconstrained fn transfer_public_to_private_authwitness_success() {
     // Check balances changes as expected
     utils::check_private_balance(env, token_contract_address, recipient, transfer_amount);
     utils::check_public_balance(env, token_contract_address, sender, transfer_amount);
+    utils::assert_supply(
+        env,
+        token_contract_address,
+        transfer_amount,
+        transfer_amount,
+    );
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]

--- a/src/token_contract/src/test/transfer_public_to_public.nr
+++ b/src/token_contract/src/test/transfer_public_to_public.nr
@@ -27,6 +27,7 @@ unconstrained fn public_transfer() {
         mint_amount - transfer_amount,
     );
     utils::check_public_balance(env, token_contract_address, recipient, transfer_amount);
+    utils::assert_supply(env, token_contract_address, mint_amount, 0);
 }
 
 #[test]
@@ -47,6 +48,7 @@ unconstrained fn public_transfer_to_self() {
     );
     // Check balances
     utils::check_public_balance(env, token_contract_address, owner, mint_amount);
+    utils::assert_supply(env, token_contract_address, mint_amount, 0);
 }
 
 #[test]
@@ -74,6 +76,7 @@ unconstrained fn public_transfer_on_behalf_of_other() {
         mint_amount - transfer_amount,
     );
     utils::check_public_balance(env, token_contract_address, recipient, transfer_amount);
+    utils::assert_supply(env, token_contract_address, mint_amount, 0);
 }
 
 #[test(should_fail_with = "attempt to subtract with overflow 'self.storage.public_balances.at(from).read() - amount'")]

--- a/src/token_contract/src/test/utils.nr
+++ b/src/token_contract/src/test/utils.nr
@@ -185,6 +185,24 @@ pub unconstrained fn get_total_supply(
     total_supply
 }
 
+pub unconstrained fn assert_supply(
+    env: TestEnvironment,
+    token_contract_address: AztecAddress,
+    expected_public_supply: u128,
+    expected_private_supply: u128,
+) {
+    let total_supply = env.view_public(Token::at(token_contract_address).total_supply());
+    let public_supply = env.view_public(Token::at(token_contract_address).public_supply());
+    let private_supply = env.view_public(Token::at(token_contract_address).private_supply());
+
+    assert(
+        total_supply == expected_public_supply + expected_private_supply,
+        "Total supply is not correct",
+    );
+    assert(public_supply == expected_public_supply, "Public supply is not correct");
+    assert(private_supply == expected_private_supply, "Private supply is not correct");
+}
+
 pub unconstrained fn check_private_balance(
     env: TestEnvironment,
     token_contract_address: AztecAddress,

--- a/src/ts/test/token.test.ts
+++ b/src/ts/test/token.test.ts
@@ -16,6 +16,7 @@ import {
   initializeTransferCommitment,
   expectTransferEvents,
   PRIVATE_ADDRESS,
+  assertSupply,
 } from './utils.js';
 
 import { TokenContractArtifact, TokenContract } from '../../../src/artifacts/Token.js';
@@ -124,7 +125,8 @@ describe('Token', () => {
     expect((await token.methods.balance_of_public(bob).simulate({ from: alice })).result).toBe(0n);
     expect((await token.methods.balance_of_private(bob).simulate({ from: alice })).result).toBe(0n);
 
-    expect((await token.methods.total_supply().simulate({ from: alice })).result).toBe(AMOUNT);
+    // After mint_to_public: all supply is public
+    await assertSupply(token, AMOUNT, 0n, alice);
 
     // alice prepares partial note for bob
     const commitment = await initializeTransferCommitment(token, alice, bobAccountManager, alice);
@@ -148,8 +150,8 @@ describe('Token', () => {
     // bob has tokens in private
     expect((await token.methods.balance_of_public(bob).simulate({ from: alice })).result).toBe(0n);
     expect((await token.methods.balance_of_private(bob).simulate({ from: bob })).result).toBe(AMOUNT);
-    // total supply is still the same
-    expect((await token.methods.total_supply().simulate({ from: alice })).result).toBe(AMOUNT);
+    // After transfer_public_to_commitment: all supply moved to private
+    await assertSupply(token, 0n, AMOUNT, alice);
   }, 300_000);
 
   it('public transfer with authwitness', async () => {
@@ -193,6 +195,8 @@ describe('Token', () => {
     expect((await token.methods.balance_of_public(alice).simulate({ from: carl })).result).toBe(0n);
     // Bob should have the a non-zero amount
     expect((await token.methods.balance_of_public(bob).simulate({ from: carl })).result).toBe(AMOUNT);
+    // Public to public: supply distribution unchanged
+    await assertSupply(token, AMOUNT, 0n, carl);
   }, 300_000);
 
   // Skipped: requires `additionalScopes` (not yet available) so carl's PXE can
@@ -243,5 +247,7 @@ describe('Token', () => {
 
     expect((await token.methods.balance_of_private(alice).simulate({ from: alice })).result).toBe(0n);
     expect((await token.methods.balance_of_private(bob).simulate({ from: bob })).result).toBe(AMOUNT);
+    // Private to private: all supply remains private
+    await assertSupply(token, 0n, AMOUNT, alice);
   }, 300_000);
 });

--- a/src/ts/test/utils.ts
+++ b/src/ts/test/utils.ts
@@ -163,9 +163,9 @@ export const assertSupply = async (
   expectedPrivateSupply: bigint,
   caller: AztecAddress,
 ) => {
-  const totalSupply = (await token.methods.total_supply().simulate({ from: caller })).result;
-  const publicSupply = (await token.methods.public_supply().simulate({ from: caller })).result;
-  const privateSupply = (await token.methods.private_supply().simulate({ from: caller })).result;
+  const { result: totalSupply } = await token.methods.total_supply().simulate({ from: caller });
+  const { result: publicSupply } = await token.methods.public_supply().simulate({ from: caller });
+  const { result: privateSupply } = await token.methods.private_supply().simulate({ from: caller });
 
   expect(totalSupply).toBe(expectedPublicSupply + expectedPrivateSupply);
   expect(publicSupply).toBe(expectedPublicSupply);

--- a/src/ts/test/utils.ts
+++ b/src/ts/test/utils.ts
@@ -157,6 +157,21 @@ export const expectTokenBalances = async (
   );
 };
 
+export const assertSupply = async (
+  token: TokenContract,
+  expectedPublicSupply: bigint,
+  expectedPrivateSupply: bigint,
+  caller: AztecAddress,
+) => {
+  const totalSupply = (await token.methods.total_supply().simulate({ from: caller })).result;
+  const publicSupply = (await token.methods.public_supply().simulate({ from: caller })).result;
+  const privateSupply = (await token.methods.private_supply().simulate({ from: caller })).result;
+
+  expect(totalSupply).toBe(expectedPublicSupply + expectedPrivateSupply);
+  expect(publicSupply).toBe(expectedPublicSupply);
+  expect(privateSupply).toBe(expectedPrivateSupply);
+};
+
 export const AMOUNT = 1000n;
 export const wad = (n: number = 1) => AMOUNT * BigInt(n);
 


### PR DESCRIPTION
# 🤖 Linear

Closes AZT-XXX

## Description

  - Add `public_supply` storage field to the token contract, tracking how much of the total supply lives in public balances
  - Derive `private_supply` as `total_supply - public_supply`
  - Add `public_supply()` and `private_supply()` view functions
  - Rename `increase_public_balance_internal` / `decrease_public_balance_internal` to `increase_public_balance_and_supply_internal` / `decrease_public_balance_and_supply_internal`
  - Add `assert_supply` test helper (Noir + JS) that validates public, private, and total supply in a single call
  - Add supply assertions to all success tests across every transfer, mint, and burn flow

  ## Motivation

  Tracking the public/private supply split gives other contracts an on-chain oracle for the token's "visibility distribution" — a property unique to Aztec. This enables use cases like dynamic risk parameters in lending markets, liquidity visibility for DEXes, governance quorum calculations, compliance circuit breakers, and more.

  ## Design decisions

  - **Track `total_supply + public_supply`** (not `private_supply`): Every change to public supply already involves a public execution, making it the natural value to update directly. `total_supply` is already needed for mint overflow checks.
  - **Separate `_increase_public_supply` / `_decrease_public_supply` internal functions**: Consistent with the existing pattern for `_increase_total_supply` / `_decrease_total_supply`. Trades a small function dispatch overhead for cleaner reuse across 6 call sites.