### PR TITLE
feat: implement ARC-403 authorization hook

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
 "src/token_contract",
+"src/token_contract/src/test/test_authorization_contract",
 "src/vault_contract",
 "src/dripper",
 "src/nft_contract",

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -53,6 +53,7 @@ interface TokenConstructorArgs {
   symbol: string;
   decimals: number;
   minter: AztecAddress;
+  authContract: AztecAddress;
 }
 
 interface DeploymentToken {
@@ -105,6 +106,7 @@ function getDeploymentData(
         symbol: tokenConfig.symbol,
         decimals: tokenConfig.decimals,
         minter: minterAddress,
+        authContract: AztecAddress.ZERO,
       },
     }));
 
@@ -279,7 +281,12 @@ async function deployContract(
       wait: { waitForStatus: TxStatus.PROPOSED },
     });
   } catch (error: unknown) {
-    const msg = error instanceof Error ? error.message : (error instanceof Object && 'cause' in error && error.cause instanceof Error ? error.cause.message : String(error));
+    const msg =
+      error instanceof Error
+        ? error.message
+        : error instanceof Object && 'cause' in error && error.cause instanceof Error
+          ? error.cause.message
+          : String(error);
     if (msg.includes('Existing nullifier')) {
       logger.info(`${label} already deployed (existing nullifier) at: ${instance.address.toString()}`);
       return { address: instance.address, status: 'existing' };
@@ -303,7 +310,7 @@ export async function deployToken(
     deployer,
     node,
     TokenContractArtifact,
-    [params.name, params.symbol, params.decimals, minter],
+    [params.name, params.symbol, params.decimals, minter, AztecAddress.ZERO],
     'constructor_with_minter',
     params.salt,
     options,
@@ -357,7 +364,7 @@ async function computeContractAddresses(config: DeploymentConfig): Promise<Compu
   const tokens: Record<string, AztecAddress> = {};
   for (const [key, tokenConfig] of Object.entries(config.contracts.tokens)) {
     const instance = await getContractInstanceFromInstantiationParams(TokenContractArtifact, {
-      constructorArgs: [tokenConfig.name, tokenConfig.symbol, tokenConfig.decimals, dripper],
+      constructorArgs: [tokenConfig.name, tokenConfig.symbol, tokenConfig.decimals, dripper, AztecAddress.ZERO],
       salt: new Fr(tokenConfig.salt),
       publicKeys: PublicKeys.default(),
       deployer: AztecAddress.ZERO,
@@ -520,7 +527,9 @@ program
   .option('--dry-run', 'Show configuration without deploying')
   .option('--output <file>', 'Write deployment JSON to file')
   .addOption(
-    new Option('-n, --network <network>', 'Target network').choices(['devnet', 'testnet', 'local-network']).default('devnet'),
+    new Option('-n, --network <network>', 'Target network')
+      .choices(['devnet', 'testnet', 'local-network'])
+      .default('devnet'),
   )
   .action(async (options: CLIOptions) => {
     try {

--- a/src/token_contract/Nargo.toml
+++ b/src/token_contract/Nargo.toml
@@ -10,3 +10,4 @@ uint_note = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v
 balance_set = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.2.0-aztecnr-rc.2", directory = "noir-projects/aztec-nr/balance-set" }
 compressed_string = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.2.0-aztecnr-rc.2", directory = "noir-projects/aztec-nr/compressed-string" }
 generic_proxy = { path = "../generic_proxy" }
+authorization_contract = { path = "src/test/test_authorization_contract" }

--- a/src/token_contract/src/main.nr
+++ b/src/token_contract/src/main.nr
@@ -496,7 +496,7 @@ pub contract Token {
      * ======================================================== */
 
     /// @notice ARC-403: calls the public authorization hook when one is configured
-    /// @dev Used for public-source operations (public balance decreases); no-ops when auth_contract is zero
+    /// @dev Invoked from external public functions; no-ops when auth_contract is zero
     /// @param from The address tokens are moved from (zero address for mints)
     /// @param amount The amount of tokens being moved
     /// @param selector The selector passed is the calling function's own selector
@@ -509,7 +509,7 @@ pub contract Token {
     }
 
     /// @notice ARC-403: calls the private authorization hook when one is configured
-    /// @dev Used for private-source operations (private note spends); no-ops when auth_contract is zero.
+    /// @dev Invoked from external private functions; no-ops when auth_contract is zero.
     ///      Runs entirely in private context - the auth call is never revealed on-chain.
     /// @param from The address tokens are moved from (zero address for mints)
     /// @param amount The amount of tokens being moved

--- a/src/token_contract/src/main.nr
+++ b/src/token_contract/src/main.nr
@@ -21,6 +21,8 @@ pub contract Token {
     use compressed_string::FieldCompressedString;
     // private balance library
     use balance_set::BalanceSet;
+    // authorization hook contract
+    use authorization_contract::AuthorizationContract;
 
     // gas-optimized max notes for initial transfer call
     global INITIAL_TRANSFER_CALL_MAX_NOTES: u32 = 2;
@@ -46,6 +48,7 @@ pub contract Token {
     /// @param total_supply The total supply of the token
     /// @param public_balances The public balances of the token
     /// @param minter The account permissioned to mint the token
+    /// @param auth_contract The authorization contract called on every transfer
     #[storage]
     struct Storage<Context> {
         name: PublicImmutable<FieldCompressedString, Context>,
@@ -55,6 +58,7 @@ pub contract Token {
         total_supply: PublicMutable<u128, Context>,
         public_balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
         minter: PublicImmutable<AztecAddress, Context>,
+        auth_contract: PublicImmutable<AztecAddress, Context>,
     }
 
     /// @notice Initializes the token with an initial supply
@@ -72,12 +76,14 @@ pub contract Token {
         decimals: u8,
         initial_supply: u128,
         to: AztecAddress,
+        auth_contract: AztecAddress,
     ) {
         self.storage.name.initialize(FieldCompressedString::from_string(name));
         self.storage.symbol.initialize(FieldCompressedString::from_string(symbol));
         self.storage.decimals.initialize(decimals);
 
         self.internal._mint_to_public(to, initial_supply);
+        self.storage.auth_contract.initialize(auth_contract);
     }
 
     /// @notice Initializes the token with a minter
@@ -85,14 +91,22 @@ pub contract Token {
     /// @param symbol The symbol of the token
     /// @param decimals The number of decimals of the token
     /// @param minter The address of the minter
+    /// @param auth_contract The address of the authorization contract (zero address to disable)
     #[external("public")]
     #[initializer]
-    fn constructor_with_minter(name: str<31>, symbol: str<31>, decimals: u8, minter: AztecAddress) {
+    fn constructor_with_minter(
+        name: str<31>,
+        symbol: str<31>,
+        decimals: u8,
+        minter: AztecAddress,
+        auth_contract: AztecAddress,
+    ) {
         self.storage.name.initialize(FieldCompressedString::from_string(name));
         self.storage.symbol.initialize(FieldCompressedString::from_string(symbol));
         self.storage.decimals.initialize(decimals);
 
         self.storage.minter.initialize(minter);
+        self.storage.auth_contract.initialize(auth_contract);
     }
 
     /** ==========================================================
@@ -113,6 +127,8 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
+        self.internal._call_auth_private(from, amount, self.context.selector().to_field());
+
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
         self.enqueue_self.increase_public_balance_internal(to, amount);
@@ -134,6 +150,8 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) -> Field {
+        self.internal._call_auth_private(from, amount, self.context.selector().to_field());
+
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
         self.enqueue_self.increase_public_balance_internal(to, amount);
@@ -158,6 +176,8 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
+        self.internal._call_auth_private(from, amount, self.context.selector().to_field());
+
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
         self.internal._increase_private_balance(to, amount);
@@ -178,6 +198,8 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
+        self.internal._call_auth_private(from, amount, self.context.selector().to_field());
+
         self.internal._decrease_private_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
 
         let completer = self.msg_sender();
@@ -203,6 +225,8 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
+        self.internal._call_auth_private(from, amount, self.context.selector().to_field());
+
         self.enqueue_self.decrease_public_balance_internal(from, amount);
 
         self.internal._increase_private_balance(to, amount);
@@ -248,6 +272,8 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
+        self.internal._call_auth_public(from, amount, self.context.selector().to_field());
+
         self.internal._decrease_public_balance(from, amount);
         self.internal._increase_public_balance(to, amount);
 
@@ -270,6 +296,8 @@ pub contract Token {
         amount: u128,
         _nonce: Field,
     ) {
+        self.internal._call_auth_public(from, amount, self.context.selector().to_field());
+
         self.internal._decrease_public_balance(from, amount);
 
         let completer = self.msg_sender();
@@ -347,6 +375,14 @@ pub contract Token {
     #[view]
     fn decimals() -> u8 {
         self.storage.decimals.read()
+    }
+
+    /// @notice Returns the ARC-403 authorization hook contract address
+    /// @return The auth contract address (zero address means authorization is disabled)
+    #[external("public")]
+    #[view]
+    fn get_auth_contract() -> AztecAddress {
+        self.storage.auth_contract.read()
     }
 
     /** ==========================================================
@@ -427,6 +463,8 @@ pub contract Token {
     #[authorize_once("from", "_nonce")]
     #[external("private")]
     fn burn_private(from: AztecAddress, amount: u128, _nonce: Field) {
+        self.internal._call_auth_private(from, amount, self.context.selector().to_field());
+
         self.internal._burn_private(from, amount);
     }
 
@@ -438,6 +476,8 @@ pub contract Token {
     #[authorize_once("from", "_nonce")]
     #[external("public")]
     fn burn_public(from: AztecAddress, amount: u128, _nonce: Field) {
+        self.internal._call_auth_public(from, amount, self.context.selector().to_field());
+
         self.internal._burn_public(from, amount);
     }
 
@@ -454,6 +494,35 @@ pub contract Token {
     /** ==========================================================
      * ================= TOKEN LIBRARIES =========================
      * ======================================================== */
+
+    /// @notice ARC-403: calls the public authorization hook when one is configured
+    /// @dev Used for public-source operations (public balance decreases); no-ops when auth_contract is zero
+    /// @param from The address tokens are moved from (zero address for mints)
+    /// @param amount The amount of tokens being moved
+    /// @param selector The selector passed is the calling function's own selector
+    #[internal("public")]
+    fn _call_auth_public(from: AztecAddress, amount: u128, selector: Field) {
+        let auth = self.storage.auth_contract.read();
+        if !auth.eq(AztecAddress::zero()) {
+            self.call(AuthorizationContract::at(auth).authorize_public(from, amount, selector));
+        }
+    }
+
+    /// @notice ARC-403: calls the private authorization hook when one is configured
+    /// @dev Used for private-source operations (private note spends); no-ops when auth_contract is zero.
+    ///      Runs entirely in private context - the auth call is never revealed on-chain.
+    /// @param from The address tokens are moved from (zero address for mints)
+    /// @param amount The amount of tokens being moved
+    /// @param selector The selector passed is the calling function's own selector
+    #[internal("private")]
+    fn _call_auth_private(from: AztecAddress, amount: u128, selector: Field) {
+        let auth = self.storage.auth_contract.read();
+        if !auth.eq(AztecAddress::zero()) {
+            AuthorizationContract::at(auth).authorize_private(from, amount, selector).call(
+                self.context,
+            );
+        }
+    }
 
     /// @notice Validates that the caller is the minter
     /// @param sender The address of the caller

--- a/src/token_contract/src/main.nr
+++ b/src/token_contract/src/main.nr
@@ -518,9 +518,7 @@ pub contract Token {
     fn _call_auth_private(from: AztecAddress, amount: u128, selector: Field) {
         let auth = self.storage.auth_contract.read();
         if !auth.eq(AztecAddress::zero()) {
-            AuthorizationContract::at(auth).authorize_private(from, amount, selector).call(
-                self.context,
-            );
+            self.call(AuthorizationContract::at(auth).authorize_private(from, amount, selector));
         }
     }
 

--- a/src/token_contract/src/test/test_authorization_contract/Nargo.toml
+++ b/src/token_contract/src/test/test_authorization_contract/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test_authorization_contract"
+authors = [""]
+compiler_version = ">=1.0.0"
+type = "contract"
+
+[dependencies]
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.2.0-aztecnr-rc.2", directory = "noir-projects/aztec-nr/aztec" }

--- a/src/token_contract/src/test/test_authorization_contract/src/main.nr
+++ b/src/token_contract/src/test/test_authorization_contract/src/main.nr
@@ -1,0 +1,24 @@
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract AuthorizationContract {
+    use aztec::{macros::functions::external, protocol::address::AztecAddress};
+
+    /// @notice Private authorization hook, called by the token in private context
+    /// @param from The address whose balance is being spent
+    /// @param amount The amount of tokens being moved
+    /// @param selector The function selector of the token operation that triggered the hook
+    #[external("private")]
+    fn authorize_private(from: AztecAddress, amount: u128, selector: Field) {
+        // no-op: allow all operations
+    }
+
+    /// @notice Public authorization hook, called by the token in public context
+    /// @param from The address whose balance is being spent
+    /// @param amount The amount of tokens being moved
+    /// @param selector The function selector of the token operation that triggered the hook
+    #[external("public")]
+    fn authorize_public(from: AztecAddress, amount: u128, selector: Field) {
+        // no-op: allow all operations
+    }
+}

--- a/src/token_contract/src/test/utils.nr
+++ b/src/token_contract/src/test/utils.nr
@@ -70,6 +70,7 @@ pub unconstrained fn deploy_token_with_initial_supply(
         18,
         initial_supply,
         to,
+        AztecAddress::zero(),
     );
     let token_contract_address = env.deploy("@token_contract/Token").with_public_initializer(
         owner,
@@ -90,6 +91,7 @@ pub unconstrained fn deploy_token_with_minter(
         "TT00000000000000000000000000000",
         18,
         minter,
+        AztecAddress::zero(),
     );
     let token_contract_address = env.deploy("@token_contract/Token").with_public_initializer(
         owner,

--- a/src/ts/test/token.test.ts
+++ b/src/ts/test/token.test.ts
@@ -56,13 +56,13 @@ describe('Token', () => {
 
       const deploymentData = await getContractInstanceFromInstantiationParams(TokenContractArtifact, {
         constructorArtifact: 'constructor_with_minter',
-        constructorArgs: ['PrivateToken', 'PT', 18, deployerWallet, deployerWallet],
+        constructorArgs: ['PrivateToken', 'PT', 18, deployerWallet, AztecAddress.ZERO],
         salt,
         deployer: deployerWallet,
       });
 
       const deployer = new ContractDeployer(TokenContractArtifact, wallet, undefined, 'constructor_with_minter');
-      const { contract } = await deployer.deploy('PrivateToken', 'PT', 18, deployerWallet, deployerWallet).send({
+      const { contract } = await deployer.deploy('PrivateToken', 'PT', 18, deployerWallet, AztecAddress.ZERO).send({
         contractAddressSalt: salt,
         from: deployerWallet,
       });
@@ -84,7 +84,7 @@ describe('Token', () => {
 
       const deploymentData = await getContractInstanceFromInstantiationParams(TokenContractArtifact, {
         constructorArtifact: 'constructor_with_initial_supply',
-        constructorArgs: ['PrivateToken', 'PT', 18, 1, deployerWallet, deployerWallet],
+        constructorArgs: ['PrivateToken', 'PT', 18, 1, deployerWallet, AztecAddress.ZERO],
         salt,
         deployer: deployerWallet,
       });
@@ -95,7 +95,7 @@ describe('Token', () => {
         'constructor_with_initial_supply',
       );
       const { contract } = await deployer
-        .deploy('PrivateToken', 'PT', 18, 1, deployerWallet, deployerWallet)
+        .deploy('PrivateToken', 'PT', 18, 1, deployerWallet, AztecAddress.ZERO)
         .send({ contractAddressSalt: salt, from: deployerWallet });
 
       const contractMetadata = await wallet.getContractMetadata(deploymentData.address);

--- a/src/ts/test/utils.ts
+++ b/src/ts/test/utils.ts
@@ -173,6 +173,7 @@ export async function deployTokenWithMinter(wallet: Wallet, deployer: AztecAddre
     'PT',
     18,
     deployer,
+    AztecAddress.ZERO,
   ).send({ ...options, from: deployer });
   return contract;
 }
@@ -191,6 +192,7 @@ export async function deployTokenWithInitialSupply(wallet: Wallet, deployer: Azt
     18,
     0,
     deployer,
+    AztecAddress.ZERO,
   ).send({ ...options, from: deployer });
   return contract;
 }
@@ -260,6 +262,7 @@ export async function deployVaultAndAssetWithMinter(
     'AT',
     6,
     deployer,
+    AztecAddress.ZERO,
   ).send({ ...options, from: deployer });
 
   // Precompute vault address (no shares needed — breaks circular dependency)
@@ -279,6 +282,7 @@ export async function deployVaultAndAssetWithMinter(
     'ST',
     18,
     vaultAddress,
+    AztecAddress.ZERO,
   ).send({ ...options, from: deployer });
 
   // Deploy vault at precomputed address with #[initializer] constructor
@@ -325,6 +329,7 @@ export async function deployVaultWithInitialDeposit(
     'ST',
     18,
     vaultAddress,
+    AztecAddress.ZERO,
   ).send({ ...options, from: deployer });
 
   // Deploy vault at precomputed address with #[initializer] constructor

--- a/src/vault_contract/src/test/utils.nr
+++ b/src/vault_contract/src/test/utils.nr
@@ -28,6 +28,7 @@ pub unconstrained fn setup_with_vault(
         "ASSET00000000000000000000000000",
         6,
         owner,
+        AztecAddress::zero(),
     );
     let asset_address =
         env.deploy("@token_contract/Token").with_public_initializer(owner, asset_initializer);
@@ -43,6 +44,7 @@ pub unconstrained fn setup_with_vault(
         "SHARES0000000000000000000000000",
         18,
         vault_address,
+        AztecAddress::zero(),
     );
     let shares_address =
         env.deploy("@token_contract/Token").with_public_initializer(owner, shares_initializer);
@@ -75,6 +77,7 @@ pub unconstrained fn setup_with_vault_initial_deposit(
         "ASSET00000000000000000000000000",
         6,
         owner,
+        AztecAddress::zero(),
     );
     let asset_address =
         env.deploy("@token_contract/Token").with_public_initializer(owner, asset_initializer);
@@ -90,6 +93,7 @@ pub unconstrained fn setup_with_vault_initial_deposit(
         "SHARES0000000000000000000000000",
         18,
         vault_address,
+        AztecAddress::zero(),
     );
     let shares_address =
         env.deploy("@token_contract/Token").with_public_initializer(owner, shares_initializer);
@@ -126,6 +130,7 @@ pub unconstrained fn setup_vault_without_shares() -> (TestEnvironment, AztecAddr
         "ASSET00000000000000000000000000",
         6,
         owner,
+        AztecAddress::zero(),
     );
     let asset_address =
         env.deploy("@token_contract/Token").with_public_initializer(owner, asset_initializer);


### PR DESCRIPTION
# 🤖 Linear

Closes AZT-783

## Description 

  - Add ARC-403 auth hook: `auth_contract` storage + constructor param, zero address disables it
  - Dispatch `authorize_private` / `authorize_public` on every transfer and burn, forwarding `(from, amount,
  selector)`
  - Expose `get_auth_contract()` view
  - Add `test_authorization_contract` stub crate and wire it as a token dep

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core token transfer/burn paths and adds optional cross-contract calls that can change execution/revert behavior and impact gas/performance. It also changes storage layout and constructor signatures, which is a breaking deployment/interface change.
> 
> **Overview**
> Adds **ARC-403 authorization hooks** to the token contract by introducing an `auth_contract` storage field, constructor parameters to set it (zero address disables), and a `get_auth_contract()` view.
> 
> All transfer and burn entrypoints now call into the configured hook (`authorize_private`/`authorize_public`) with `(from, amount, selector)` before debiting balances/notes; a stub `test_authorization_contract` dependency is added and tests deploy the token with `AztecAddress::zero()` for the hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5010380895e2e2153c32f9c7542155ad2845620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->