### PR TITLE
chore: bump aztec to v4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defi-wonderland/aztec-standards",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/defi-wonderland/aztec-standards.git"
@@ -50,7 +50,7 @@
     "vitest": "4.0.17"
   },
   "config": {
-    "aztecVersion": "4.3.0"
+    "aztecVersion": "4.3.1"
   },
   "engines": {
     "node": ">=22"

--- a/src/dripper/Nargo.toml
+++ b/src/dripper/Nargo.toml
@@ -5,5 +5,5 @@ compiler_version = ">=1.0.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/aztec" }
 token = { path = "../token_contract" }

--- a/src/escrow_contract/Nargo.toml
+++ b/src/escrow_contract/Nargo.toml
@@ -5,8 +5,8 @@ compiler_version = ">=1.0.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/aztec" }
-serde = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/noir-protocol-circuits/crates/serde" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/aztec" }
+serde = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/noir-protocol-circuits/crates/serde" }
 token = { path = "../token_contract" }
 nft = { path = "../nft_contract" }
 sha512 = { git = "https://github.com/noir-lang/sha512", tag = "mv/use-bool-over-u1" }

--- a/src/escrow_contract/src/test/test_logic_contract/Nargo.toml
+++ b/src/escrow_contract/src/test/test_logic_contract/Nargo.toml
@@ -5,7 +5,7 @@ compiler_version = ">=1.0.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/aztec" }
 escrow_contract = { path = "../../../" }
 token = { path = "../../../../token_contract" }
 nft = { path = "../../../../nft_contract" }

--- a/src/generic_proxy/Nargo.toml
+++ b/src/generic_proxy/Nargo.toml
@@ -5,4 +5,4 @@ compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/aztec" }

--- a/src/nft_contract/Nargo.toml
+++ b/src/nft_contract/Nargo.toml
@@ -5,6 +5,6 @@ compiler_version = ">=1.0.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/aztec" }
-compressed_string = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/compressed-string" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/aztec" }
+compressed_string = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/compressed-string" }
 generic_proxy = { path = "../generic_proxy" }

--- a/src/token_contract/Nargo.toml
+++ b/src/token_contract/Nargo.toml
@@ -5,8 +5,8 @@ compiler_version = ">=1.0.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/aztec" }
-uint_note = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/uint-note" }
-balance_set = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/balance-set" }
-compressed_string = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/compressed-string" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/aztec" }
+uint_note = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/uint-note" }
+balance_set = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/balance-set" }
+compressed_string = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/compressed-string" }
 generic_proxy = { path = "../generic_proxy" }

--- a/src/vault_contract/Nargo.toml
+++ b/src/vault_contract/Nargo.toml
@@ -5,6 +5,6 @@ compiler_version = ">=1.0.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/aztec" }
 token_contract = { path = "../token_contract" }
 generic_proxy = { path = "../generic_proxy" }

--- a/src/vault_deployer/Nargo.toml
+++ b/src/vault_deployer/Nargo.toml
@@ -5,6 +5,6 @@ compiler_version = ">=1.0.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.0", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.3.1", directory = "noir-projects/aztec-nr/aztec" }
 vault_contract = { path = "../vault_contract" }
 token_contract = { path = "../token_contract" }


### PR DESCRIPTION
Bumps aztec-packages deps and `aztecVersion` from v4.3.0 → v4.3.1 to cut a 4.3.1 prerelease for the fairies' poc wallet testing.

`aztec-nr` is byte-identical between v4.3.0 and v4.3.1 (the 4.3.1 patch only touched prover-node, TS l2_tips_store, and release-image packaging), so this is a no-op at the contract/compile level.

Opening this PR triggers the Pre-Release workflow → publishes `@defi-wonderland/aztec-standards@4.3.1-prerelease.<sha>`.